### PR TITLE
Julia added frontend for UpdateGradeInfo in job

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,23 +1,23 @@
 body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-      sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-  
-  code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-      monospace;
-  }
-  .color-nav{
-    background-color: rgb(0, 54, 96);
-  } 
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
-  .btn-primary, .btn-primary:hover, .btn-primary:focus{
-    background-color: #34859b;
-    border-color: #34859b;
-  } 
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
+}
+.color-nav {
+  background-color: rgb(0, 54, 96);
+}
 
-  
+.btn-primary,
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: #34859b;
+  border-color: #34859b;
+}

--- a/frontend/src/main/components/Jobs/JobComingSoon.js
+++ b/frontend/src/main/components/Jobs/JobComingSoon.js
@@ -1,5 +1,0 @@
-function JobComingSoon() {
-  return <p>Coming Soon! (The form for this job has not yet been created)</p>;
-}
-
-export default JobComingSoon;

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -18,7 +18,7 @@ const UpdateGradeInfoForm = ({ callback }) => {
               type="submit"
               data-testid="updateGradeInfoSubmit"
             >
-              Update Grade Info Submit
+              Update Grades
             </Button>
           </Col>
         </Row>

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -1,7 +1,6 @@
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
 
 const UpdateGradeInfoForm = ({ callback }) => {
-
   const handleSubmit = (event) => {
     event.preventDefault();
     callback();

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+
+import { quarterRange } from "main/utils/quarterUtilities";
+
+import { useSystemInfo } from "main/utils/systemInfo";
+import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
+import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
+import { useBackend } from "main/utils/useBackend";
+
+const UpdateGradeInfoForm = ({ callback }) => {
+  const { data: systemInfo } = useSystemInfo();
+
+  // Stryker disable OptionalChaining
+  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+  // Stryker enable OptionalChaining
+
+  const quarters = quarterRange(startQtr, endQtr);
+
+  // Stryker disable all : not sure how to test/mock local storage
+  const localSubject = localStorage.getItem("BasicSearch.Subject");
+  const localQuarter = localStorage.getItem("BasicSearch.Quarter");
+
+  const {
+    data: subjects,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/UCSBSubjects/all"],
+    { method: "GET", url: "/api/UCSBSubjects/all" },
+    [],
+  );
+
+  const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
+  const [subject, setSubject] = useState(localSubject || "ANTH");
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    console.log("UpdateCoursesJobForm: quarter", quarter);
+    console.log("UpdateCoursesJobForm: subject", subject);
+    callback({ quarter, subject });
+  };
+
+  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row>
+          <Col md="auto">
+            <SingleQuarterDropdown
+              quarters={quarters}
+              quarter={quarter}
+              setQuarter={setQuarter}
+              controlId={"BasicSearch.Quarter"}
+            />
+          </Col>
+          <Col md="auto">
+            <SingleSubjectDropdown
+              subjects={subjects}
+              subject={subject}
+              setSubject={setSubject}
+              controlId={"BasicSearch.Subject"}
+            />
+          </Col>
+        </Row>
+        <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
+          <Col md="auto">
+            <Button variant="primary" type="submit" data-testid="updateCourses">
+              Update Courses
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default UpdateGradeInfoForm;

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -16,9 +16,9 @@ const UpdateGradeInfoForm = ({ callback }) => {
             <Button
               variant="primary"
               type="submit"
-              data-testid="updateGradeInfo"
+              data-testid="updateGradeInfoSubmit"
             >
-              Update Grade Info
+              Update Grade Info Submit
             </Button>
           </Col>
         </Row>

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -2,11 +2,7 @@ import { Form, Button, Container, Row, Col } from "react-bootstrap";
 import { useBackend } from "main/utils/useBackend";
 
 const UpdateGradeInfoForm = ({ callback }) => {
-
-  const {
-    error: _error,
-    status: _status,
-  } = useBackend(
+  const { error: _error, status: _status } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
     ["/api/jobs/launch/uploadGradeData"],
     { method: "POST", url: "/api/jobs/launch/uploadGradeData" },
@@ -24,7 +20,7 @@ const UpdateGradeInfoForm = ({ callback }) => {
       <Container>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">
-            <Button variant="primary" type="submit" data-testid="updateCourses">
+            <Button variant="primary" type="submit" data-testid="updateGradeData">
               Update Grade Info
             </Button>
           </Col>

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -20,7 +20,11 @@ const UpdateGradeInfoForm = ({ callback }) => {
       <Container>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">
-            <Button variant="primary" type="submit" data-testid="updateGradeData">
+            <Button
+              variant="primary"
+              type="submit"
+              data-testid="updateGradeData"
+            >
               Update Grade Info
             </Button>
           </Col>

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -1,74 +1,31 @@
-import { useState } from "react";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
-
-import { quarterRange } from "main/utils/quarterUtilities";
-
-import { useSystemInfo } from "main/utils/systemInfo";
-import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
-import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
 import { useBackend } from "main/utils/useBackend";
 
 const UpdateGradeInfoForm = ({ callback }) => {
-  const { data: systemInfo } = useSystemInfo();
-
-  // Stryker disable OptionalChaining
-  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
-  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
-  // Stryker enable OptionalChaining
-
-  const quarters = quarterRange(startQtr, endQtr);
-
-  // Stryker disable all : not sure how to test/mock local storage
-  const localSubject = localStorage.getItem("BasicSearch.Subject");
-  const localQuarter = localStorage.getItem("BasicSearch.Quarter");
 
   const {
-    data: subjects,
     error: _error,
     status: _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/UCSBSubjects/all"],
-    { method: "GET", url: "/api/UCSBSubjects/all" },
+    ["/api/jobs/launch/uploadGradeData"],
+    { method: "POST", url: "/api/jobs/launch/uploadGradeData" },
     [],
   );
 
-  const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
-  const [subject, setSubject] = useState(localSubject || "ANTH");
-
   const handleSubmit = (event) => {
     event.preventDefault();
-    console.log("UpdateCoursesJobForm: quarter", quarter);
-    console.log("UpdateCoursesJobForm: subject", subject);
-    callback({ quarter, subject });
+    callback();
   };
 
   // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (
     <Form onSubmit={handleSubmit}>
       <Container>
-        <Row>
-          <Col md="auto">
-            <SingleQuarterDropdown
-              quarters={quarters}
-              quarter={quarter}
-              setQuarter={setQuarter}
-              controlId={"BasicSearch.Quarter"}
-            />
-          </Col>
-          <Col md="auto">
-            <SingleSubjectDropdown
-              subjects={subjects}
-              subject={subject}
-              setSubject={setSubject}
-              controlId={"BasicSearch.Subject"}
-            />
-          </Col>
-        </Row>
         <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
           <Col md="auto">
             <Button variant="primary" type="submit" data-testid="updateCourses">
-              Update Courses
+              Update Grade Info
             </Button>
           </Col>
         </Row>

--- a/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
+++ b/frontend/src/main/components/Jobs/UpdateGradeInfoForm.js
@@ -1,13 +1,6 @@
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
-import { useBackend } from "main/utils/useBackend";
 
 const UpdateGradeInfoForm = ({ callback }) => {
-  const { error: _error, status: _status } = useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/jobs/launch/uploadGradeData"],
-    { method: "POST", url: "/api/jobs/launch/uploadGradeData" },
-    [],
-  );
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -23,7 +16,7 @@ const UpdateGradeInfoForm = ({ callback }) => {
             <Button
               variant="primary"
               type="submit"
-              data-testid="updateGradeData"
+              data-testid="updateGradeInfo"
             >
               Update Grade Info
             </Button>

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -53,8 +53,6 @@ const AdminJobsPage = () => {
     method: "POST",
   });
 
-  
-
   // Stryker disable all
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
@@ -139,8 +137,7 @@ const AdminJobsPage = () => {
     },
     {
       name: "Update Grade Info",
-      form: <UpdateGradeInfoForm
-        callback={submitUpdateGradeInfoJob}/>,
+      form: <UpdateGradeInfoForm callback={submitUpdateGradeInfoJob} />,
     },
   ];
 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -4,7 +4,8 @@ import JobsTable from "main/components/Jobs/JobsTable";
 import { useBackend } from "main/utils/useBackend";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
-import JobComingSoon from "main/components/Jobs/JobComingSoon";
+//import JobComingSoon from "main/components/Jobs/JobComingSoon";
+import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm"
 
 import { useBackendMutation } from "main/utils/useBackend";
 import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
@@ -122,7 +123,7 @@ const AdminJobsPage = () => {
     },
     {
       name: "Update Grade Info",
-      form: <JobComingSoon />,
+      form: <UpdateGradeInfoForm />,
     },
   ];
 

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -4,7 +4,6 @@ import JobsTable from "main/components/Jobs/JobsTable";
 import { useBackend } from "main/utils/useBackend";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
-//import JobComingSoon from "main/components/Jobs/JobComingSoon";
 import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm"
 
 import { useBackendMutation } from "main/utils/useBackend";

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -4,7 +4,7 @@ import JobsTable from "main/components/Jobs/JobsTable";
 import { useBackend } from "main/utils/useBackend";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
-import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm"
+import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import UpdateCoursesJobForm from "main/components/Jobs/UpdateCoursesJobForm";
@@ -48,6 +48,13 @@ const AdminJobsPage = () => {
     method: "POST",
   });
 
+  const objectToAxiosParamsUpdateGradeInfoJob = () => ({
+    url: "/api/jobs/launch/uploadGradeData",
+    method: "POST",
+  });
+
+  
+
   // Stryker disable all
   const updateCoursesJobMutation = useBackendMutation(
     objectToAxiosParamsUpdateCoursesJob,
@@ -65,6 +72,12 @@ const AdminJobsPage = () => {
     {},
     ["/api/jobs/all"],
   );
+
+  const updateGradeInfoJobMutation = useBackendMutation(
+    objectToAxiosParamsUpdateGradeInfoJob,
+    {},
+    ["/api/jobs/all"],
+  );
   // Stryker restore all
 
   const submitUpdateCoursesJob = async (data) => {
@@ -77,6 +90,10 @@ const AdminJobsPage = () => {
 
   const submitUpdateCoursesByQuarterRangeJob = async (data) => {
     updateCoursesByQuarterRangeJobMutation.mutate(data);
+  };
+
+  const submitUpdateGradeInfoJob = async () => {
+    updateGradeInfoJobMutation.mutate();
   };
 
   // Stryker disable all
@@ -122,7 +139,8 @@ const AdminJobsPage = () => {
     },
     {
       name: "Update Grade Info",
-      form: <UpdateGradeInfoForm />,
+      form: <UpdateGradeInfoForm
+        callback={submitUpdateGradeInfoJob}/>,
     },
   ];
 

--- a/frontend/src/stories/components/Jobs/JobsTable.stories.mdx
+++ b/frontend/src/stories/components/Jobs/JobsTable.stories.mdx
@@ -3,11 +3,7 @@ import { action } from "@storybook/addon-actions";
 import JobsTable from "main/components/Jobs/JobsTable";
 import jobsFixtures from "fixtures/jobsFixtures";
 
-
-<Meta
-  title="components/Jobs/JobsTable"
-  component={JobsTable}
-/>
+<Meta title="components/Jobs/JobsTable" component={JobsTable} />
 
 # Jobs
 

--- a/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/TestJobForm.stories.mdx
@@ -2,16 +2,14 @@ import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { action } from "@storybook/addon-actions";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 
-<Meta
-  title="components/Jobs/TestJobForm"
-  component={TestJobForm}
-/>
+<Meta title="components/Jobs/TestJobForm" component={TestJobForm} />
 
 # TestJobForm
 
 A form for submitting the test job, with:
-* a checkbox for whether the job should fail or not
-* a numeric field for the amount of time the job should sleep (to simulate a long-running job)
+
+- a checkbox for whether the job should fail or not
+- a numeric field for the amount of time the job should sleep (to simulate a long-running job)
 
 <Canvas>
   <Story name="uncontrolled">

--- a/frontend/src/stories/components/Jobs/UpdateGradeInfoForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UpdateGradeInfoForm.stories.js
@@ -1,0 +1,38 @@
+import React from "react";
+
+import UpdateGradeInfoJobForm from "main/components/Jobs/UpdateGradeInfoForm";
+import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+export default {
+  title: "components/Jobs/UpdateGradeInfoForm",
+  component: UpdateGradeInfoJobForm,
+  parameters: {
+    mockData: [
+      {
+        url: "/api/UCSBSubjects/all",
+        method: "GET",
+        status: 200,
+        response: ucsbSubjectsFixtures.threeSubjects,
+      },
+      {
+        url: "/api/systemInfo",
+        method: "GET",
+        status: 200,
+        response: systemInfoFixtures.showingBoth,
+      },
+    ],
+  },
+};
+
+const Template = (args) => {
+  return <UpdateGradeInfoJobForm {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  callback: (data) => {
+    console.log("Submit was clicked, data=", data);
+  },
+};

--- a/frontend/src/stories/components/Jobs/UpdateGradeInfoForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UpdateGradeInfoForm.stories.js
@@ -3,7 +3,7 @@ import UpdateGradeInfoJobForm from "main/components/Jobs/UpdateGradeInfoForm";
 
 export default {
   title: "components/Jobs/UpdateGradeInfoForm",
-  component: UpdateGradeInfoJobForm
+  component: UpdateGradeInfoJobForm,
 };
 
 const Template = (args) => {

--- a/frontend/src/stories/components/Jobs/UpdateGradeInfoForm.stories.js
+++ b/frontend/src/stories/components/Jobs/UpdateGradeInfoForm.stories.js
@@ -1,28 +1,9 @@
 import React from "react";
-
 import UpdateGradeInfoJobForm from "main/components/Jobs/UpdateGradeInfoForm";
-import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
   title: "components/Jobs/UpdateGradeInfoForm",
-  component: UpdateGradeInfoJobForm,
-  parameters: {
-    mockData: [
-      {
-        url: "/api/UCSBSubjects/all",
-        method: "GET",
-        status: 200,
-        response: ucsbSubjectsFixtures.threeSubjects,
-      },
-      {
-        url: "/api/systemInfo",
-        method: "GET",
-        status: 200,
-        response: systemInfoFixtures.showingBoth,
-      },
-    ],
-  },
+  component: UpdateGradeInfoJobForm
 };
 
 const Template = (args) => {

--- a/frontend/src/stories/components/Utils/Plaintext.stories.mdx
+++ b/frontend/src/stories/components/Utils/Plaintext.stories.mdx
@@ -1,12 +1,9 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { action } from "@storybook/addon-actions";
 import Plaintext from "main/components/Utils/Plaintext";
-const multiline = "foo\nbar\n\nbaz"
+const multiline = "foo\nbar\n\nbaz";
 
-<Meta
-  title="components/Utils/Plaintext"
-  component={Plaintext}
-/>
+<Meta title="components/Utils/Plaintext" component={Plaintext} />
 
 # Jobs
 

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import UpdateCoursesJobForm from "main/components/Jobs/UpdateGradeInfoForm";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+const queryClient = new QueryClient();
+
+describe("UpdateGradeInfoForm tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  it("renders correctly", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UpdateGradeInfoForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(/Update Grade Info/)).toBeInTheDocument();
+  });
+
+  test("renders without crashing when fallback values are used", async () => {
+    axiosMock.onGet("/api/systemInfo").reply(200, {
+      springH2ConsoleEnabled: false,
+      showSwaggerUILink: false,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UpdateGradeInfoForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    // Make sure the first and last options
+    expect(
+      await screen.findByTestId("updateGradeData")
+    );
+  });
+});

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -45,6 +45,6 @@ describe("UpdateGradeInfoForm tests", () => {
     );
 
     // Make sure the first and last options
-    expect(await screen.findByTestId("updateGradeData"));
+    expect(await screen.findByTestId("updateGradeData")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -27,7 +27,7 @@ describe("UpdateGradeInfoForm tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.getByText(/Update Grade Info/)).toBeInTheDocument();
+    expect(screen.getByText(/Update Grades/)).toBeInTheDocument();
   });
 
   test("renders without crashing when fallback values are used", async () => {

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
-import UpdateCoursesJobForm from "main/components/Jobs/UpdateGradeInfoForm";
+import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 import axios from "axios";

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -45,6 +45,8 @@ describe("UpdateGradeInfoForm tests", () => {
     );
 
     // Make sure the first and last options
-    expect(await screen.findByTestId("updateGradeInfoSubmit")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("updateGradeInfoSubmit"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -45,8 +45,6 @@ describe("UpdateGradeInfoForm tests", () => {
     );
 
     // Make sure the first and last options
-    expect(
-      await screen.findByTestId("updateGradeData")
-    );
+    expect(await screen.findByTestId("updateGradeData"));
   });
 });

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -45,6 +45,6 @@ describe("UpdateGradeInfoForm tests", () => {
     );
 
     // Make sure the first and last options
-    expect(await screen.findByTestId("updateGradeInfo")).toBeInTheDocument();
+    expect(await screen.findByTestId("updateGradeInfoSubmit")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateGradeInfoForm.test.js
@@ -45,6 +45,6 @@ describe("UpdateGradeInfoForm tests", () => {
     );
 
     // Make sure the first and last options
-    expect(await screen.findByTestId("updateGradeData")).toBeInTheDocument();
+    expect(await screen.findByTestId("updateGradeInfo")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -232,7 +232,7 @@ describe("AdminJobsPage tests", () => {
     );
 
     expect(
-      await screen.findByText("Update Grade Info Submit"),
+      await screen.findByText("Update Grades"),
     ).toBeInTheDocument();
 
     const updateGradeButton = screen.getByText(

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -231,13 +231,9 @@ describe("AdminJobsPage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(
-      await screen.findByText("Update Grades"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Update Grades")).toBeInTheDocument();
 
-    const updateGradeButton = screen.getByText(
-      "Update Grade Info",
-    );
+    const updateGradeButton = screen.getByText("Update Grade Info");
     expect(updateGradeButton).toBeInTheDocument();
     updateGradeButton.click();
 

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -221,4 +221,35 @@ describe("AdminJobsPage tests", () => {
       "/api/jobs/launch/updateCoursesRangeOfQuarters?start_quarterYYYYQ=20212&end_quarterYYYYQ=20213",
     );
   });
+
+  test("user can submit update grade info", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminJobsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByText("Update Grade Info Submit"),
+    ).toBeInTheDocument();
+
+    const updateGradeButton = screen.getByText(
+      "Update Grade Info",
+    );
+    expect(updateGradeButton).toBeInTheDocument();
+    updateGradeButton.click();
+
+    const submitGradeButton = screen.getByTestId("updateGradeInfoSubmit");
+    expect(submitGradeButton).toBeInTheDocument();
+
+    submitGradeButton.click();
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].url).toBe(
+      "/api/jobs/launch/uploadGradeData",
+    );
+  });
 });


### PR DESCRIPTION
Added UpdateGradeInfoForm.js that adds a button to update the grade info and used the form while deleting placeholder form.
Also created test file for UpdateGradeInfoForm as well as editing existing test in admin job page tests.
Deployed at:  https://proj-jchandev-dev.dokku-02.cs.ucsb.edu

To test this: Log in as admin. Then click on the admin dropdown, and click on manage jobs. Then click on update grade info dropdown and then click update grades.
Created test for the form and also added it to storybook. 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/d6eb38ae-e5b3-43f7-85c9-73b6ad7aa076)
If button worked should have this: 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/ed4ad983-5f9c-416a-9dc9-1b65f93ba8b3)

Storybook link: https://ucsb-cs156-s24.github.io/proj-courses-s24-4pm-2/prs/18/storybook/?path=/docs/components-jobs-updategradeinfoform--default
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/b5964d1a-8ef2-442c-9d35-c7c7abcfc600)

closes #5 
