### PR TITLE
Evan course history search output correction

### DIFF
--- a/frontend/src/fixtures/sectionFixtures.js
+++ b/frontend/src/fixtures/sectionFixtures.js
@@ -451,139 +451,139 @@ export const fiveSections = [
 ];
 
 export const differentQuarterSections = [
-    {
-      courseInfo: {
-        quarter: "20221",
-        courseId: "ECE       1A -1",
-        title: "COMP ENGR SEMINAR",
-        description:
-          "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
-      },
-      section: {
-        enrollCode: "12583",
-        section: "0100",
-        session: null,
-        classClosed: null,
-        courseCancelled: null,
-        gradingOptionCode: null,
-        enrolledTotal: 84,
-        maxEnroll: 100,
-        secondaryStatus: null,
-        departmentApprovalRequired: false,
-        instructorApprovalRequired: false,
-        restrictionLevel: null,
-        restrictionMajor: "+PRCME+CMPEN",
-        restrictionMajorPass: null,
-        restrictionMinor: null,
-        restrictionMinorPass: null,
-        concurrentCourses: [],
-        timeLocations: [
-          {
-            room: "1930",
-            building: "BUCHN",
-            roomCapacity: "100",
-            days: "M      ",
-            beginTime: "15:00",
-            endTime: "15:50",
-          },
-        ],
-        instructors: [
-          {
-            instructor: "WANG L C",
-            functionCode: "Teaching and in charge",
-          },
-        ],
-      },
+  {
+    courseInfo: {
+      quarter: "20221",
+      courseId: "ECE       1A -1",
+      title: "COMP ENGR SEMINAR",
+      description:
+        "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
     },
-    {
-        courseInfo: {
-          quarter: "20222",
-          courseId: "ECE       1A -1",
-          title: "COMP ENGR SEMINAR",
-          description:
-            "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+    section: {
+      enrollCode: "12583",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 100,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: "+PRCME+CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1930",
+          building: "BUCHN",
+          roomCapacity: "100",
+          days: "M      ",
+          beginTime: "15:00",
+          endTime: "15:50",
         },
-        section: {
-          enrollCode: "12583",
-          section: "0100",
-          session: null,
-          classClosed: null,
-          courseCancelled: null,
-          gradingOptionCode: null,
-          enrolledTotal: 84,
-          maxEnroll: 100,
-          secondaryStatus: null,
-          departmentApprovalRequired: false,
-          instructorApprovalRequired: false,
-          restrictionLevel: null,
-          restrictionMajor: "+PRCME+CMPEN",
-          restrictionMajorPass: null,
-          restrictionMinor: null,
-          restrictionMinorPass: null,
-          concurrentCourses: [],
-          timeLocations: [
-            {
-              room: "1930",
-              building: "BUCHN",
-              roomCapacity: "100",
-              days: "M      ",
-              beginTime: "15:00",
-              endTime: "15:50",
-            },
-          ],
-          instructors: [
-            {
-              instructor: "WANG L C",
-              functionCode: "Teaching and in charge",
-            },
-          ],
+      ],
+      instructors: [
+        {
+          instructor: "WANG L C",
+          functionCode: "Teaching and in charge",
         },
-      },
-    {
-        courseInfo: {
-          quarter: "20231",
-          courseId: "ECE       1A -1",
-          title: "COMP ENGR SEMINAR",
-          description:
-            "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+      ],
+    },
+  },
+  {
+    courseInfo: {
+      quarter: "20222",
+      courseId: "ECE       1A -1",
+      title: "COMP ENGR SEMINAR",
+      description:
+        "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+    },
+    section: {
+      enrollCode: "12583",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 100,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: "+PRCME+CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1930",
+          building: "BUCHN",
+          roomCapacity: "100",
+          days: "M      ",
+          beginTime: "15:00",
+          endTime: "15:50",
         },
-        section: {
-          enrollCode: "12583",
-          section: "0100",
-          session: null,
-          classClosed: null,
-          courseCancelled: null,
-          gradingOptionCode: null,
-          enrolledTotal: 84,
-          maxEnroll: 100,
-          secondaryStatus: null,
-          departmentApprovalRequired: false,
-          instructorApprovalRequired: false,
-          restrictionLevel: null,
-          restrictionMajor: "+PRCME+CMPEN",
-          restrictionMajorPass: null,
-          restrictionMinor: null,
-          restrictionMinorPass: null,
-          concurrentCourses: [],
-          timeLocations: [
-            {
-              room: "1930",
-              building: "BUCHN",
-              roomCapacity: "100",
-              days: "M      ",
-              beginTime: "15:00",
-              endTime: "15:50",
-            },
-          ],
-          instructors: [
-            {
-              instructor: "WANG L C",
-              functionCode: "Teaching and in charge",
-            },
-          ],
+      ],
+      instructors: [
+        {
+          instructor: "WANG L C",
+          functionCode: "Teaching and in charge",
         },
-      },
-  ];
+      ],
+    },
+  },
+  {
+    courseInfo: {
+      quarter: "20231",
+      courseId: "ECE       1A -1",
+      title: "COMP ENGR SEMINAR",
+      description:
+        "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+    },
+    section: {
+      enrollCode: "12583",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 84,
+      maxEnroll: 100,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: "+PRCME+CMPEN",
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: [],
+      timeLocations: [
+        {
+          room: "1930",
+          building: "BUCHN",
+          roomCapacity: "100",
+          days: "M      ",
+          beginTime: "15:00",
+          endTime: "15:50",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "WANG L C",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+];
 
 export const gigaSections = [
   {

--- a/frontend/src/fixtures/sectionFixtures.js
+++ b/frontend/src/fixtures/sectionFixtures.js
@@ -450,6 +450,141 @@ export const fiveSections = [
   },
 ];
 
+export const differentQuarterSections = [
+    {
+      courseInfo: {
+        quarter: "20221",
+        courseId: "ECE       1A -1",
+        title: "COMP ENGR SEMINAR",
+        description:
+          "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+      },
+      section: {
+        enrollCode: "12583",
+        section: "0100",
+        session: null,
+        classClosed: null,
+        courseCancelled: null,
+        gradingOptionCode: null,
+        enrolledTotal: 84,
+        maxEnroll: 100,
+        secondaryStatus: null,
+        departmentApprovalRequired: false,
+        instructorApprovalRequired: false,
+        restrictionLevel: null,
+        restrictionMajor: "+PRCME+CMPEN",
+        restrictionMajorPass: null,
+        restrictionMinor: null,
+        restrictionMinorPass: null,
+        concurrentCourses: [],
+        timeLocations: [
+          {
+            room: "1930",
+            building: "BUCHN",
+            roomCapacity: "100",
+            days: "M      ",
+            beginTime: "15:00",
+            endTime: "15:50",
+          },
+        ],
+        instructors: [
+          {
+            instructor: "WANG L C",
+            functionCode: "Teaching and in charge",
+          },
+        ],
+      },
+    },
+    {
+        courseInfo: {
+          quarter: "20222",
+          courseId: "ECE       1A -1",
+          title: "COMP ENGR SEMINAR",
+          description:
+            "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+        },
+        section: {
+          enrollCode: "12583",
+          section: "0100",
+          session: null,
+          classClosed: null,
+          courseCancelled: null,
+          gradingOptionCode: null,
+          enrolledTotal: 84,
+          maxEnroll: 100,
+          secondaryStatus: null,
+          departmentApprovalRequired: false,
+          instructorApprovalRequired: false,
+          restrictionLevel: null,
+          restrictionMajor: "+PRCME+CMPEN",
+          restrictionMajorPass: null,
+          restrictionMinor: null,
+          restrictionMinorPass: null,
+          concurrentCourses: [],
+          timeLocations: [
+            {
+              room: "1930",
+              building: "BUCHN",
+              roomCapacity: "100",
+              days: "M      ",
+              beginTime: "15:00",
+              endTime: "15:50",
+            },
+          ],
+          instructors: [
+            {
+              instructor: "WANG L C",
+              functionCode: "Teaching and in charge",
+            },
+          ],
+        },
+      },
+    {
+        courseInfo: {
+          quarter: "20231",
+          courseId: "ECE       1A -1",
+          title: "COMP ENGR SEMINAR",
+          description:
+            "Introductory seminar to expose students to a broad range of topics in computer   engineering.",
+        },
+        section: {
+          enrollCode: "12583",
+          section: "0100",
+          session: null,
+          classClosed: null,
+          courseCancelled: null,
+          gradingOptionCode: null,
+          enrolledTotal: 84,
+          maxEnroll: 100,
+          secondaryStatus: null,
+          departmentApprovalRequired: false,
+          instructorApprovalRequired: false,
+          restrictionLevel: null,
+          restrictionMajor: "+PRCME+CMPEN",
+          restrictionMajorPass: null,
+          restrictionMinor: null,
+          restrictionMinorPass: null,
+          concurrentCourses: [],
+          timeLocations: [
+            {
+              room: "1930",
+              building: "BUCHN",
+              roomCapacity: "100",
+              days: "M      ",
+              beginTime: "15:00",
+              endTime: "15:50",
+            },
+          ],
+          instructors: [
+            {
+              instructor: "WANG L C",
+              functionCode: "Teaching and in charge",
+            },
+          ],
+        },
+      },
+  ];
+
 export const gigaSections = [
   {
     courseInfo: {

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -38,7 +38,11 @@ export default function CourseOverTimeIndexPage() {
       <div className="pt-2">
         <h5>Welcome to the UCSB Course History Search!</h5>
         <CourseOverTimeSearchForm fetchJSON={fetchCourseOverTimeJSON} />
-        <SectionsOverTimeTable sections={courseJSON.sort((a, b) => b.courseInfo.quarter.localeCompare(a.courseInfo.quarter))} />
+        <SectionsOverTimeTable
+          sections={courseJSON.sort((a, b) =>
+            b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+          )}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeIndexPage.js
@@ -38,7 +38,7 @@ export default function CourseOverTimeIndexPage() {
       <div className="pt-2">
         <h5>Welcome to the UCSB Course History Search!</h5>
         <CourseOverTimeSearchForm fetchJSON={fetchCourseOverTimeJSON} />
-        <SectionsOverTimeTable sections={courseJSON} />
+        <SectionsOverTimeTable sections={courseJSON.sort((a, b) => b.courseInfo.quarter.localeCompare(a.courseInfo.quarter))} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeIndexPage.test.js
@@ -7,7 +7,10 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { threeSections, differentQuarterSections } from "fixtures/sectionFixtures";
+import {
+  threeSections,
+  differentQuarterSections,
+} from "fixtures/sectionFixtures";
 import { allTheSubjects } from "fixtures/subjectFixtures";
 import userEvent from "@testing-library/user-event";
 
@@ -96,7 +99,6 @@ describe("CourseOverTimeIndexPage tests", () => {
     expect(screen.getByText("ECE 1A")).toBeInTheDocument();
   });
 
-
   test("passes sorted sections to SectionsOverTimeTable", async () => {
     // Mock the response of the API call with differentQuarterSections data
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
@@ -104,7 +106,10 @@ describe("CourseOverTimeIndexPage tests", () => {
       .onGet("/api/public/courseovertime/search")
       .reply(200, differentQuarterSections);
 
-    const spy = jest.spyOn(require("main/components/Sections/SectionsOverTimeTable"), "default");
+    const spy = jest.spyOn(
+      require("main/components/Sections/SectionsOverTimeTable"),
+      "default",
+    );
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -113,7 +118,7 @@ describe("CourseOverTimeIndexPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-  
+
     const selectStartQuarter = screen.getByLabelText("Start Quarter");
     userEvent.selectOptions(selectStartQuarter, "20222");
     const selectEndQuarter = screen.getByLabelText("End Quarter");
@@ -147,13 +152,16 @@ describe("CourseOverTimeIndexPage tests", () => {
       subjectArea: "ANTH",
       courseNumber: "130A",
     });
-  
+
     // Check that SectionsOverTimeTable received the sorted sections data
-    const sortedSections = differentQuarterSections.sort((a, b) => b.courseInfo.quarter.localeCompare(a.courseInfo.quarter));
-    expect(spy).toHaveBeenCalledWith({ sections: sortedSections }, expect.anything());
+    const sortedSections = differentQuarterSections.sort((a, b) =>
+      b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      { sections: sortedSections },
+      expect.anything(),
+    );
 
     spy.mockRestore();
   });
-
-
 });


### PR DESCRIPTION
In this pull request, I have updated the CourseOverTimeIndexPage to pass a version of the courseJSON that is sorted by decreasing quarter to the SectionsOverTimeTable, thus enabling it to render in the proper order when called. 

Here is the observed bug for a search on our team's dokku server:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/ae9c564d-434f-4974-8fe3-81283df9f60e)


And here is the fixed version on my dev development:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/e4506d9c-a2c5-4a4d-84af-64a3f129a202)

Originally, it goes oldest to newest, (winter first, then spring), but I have changed it to be the opposite.

Additionally, I had to fix the tests for CourseOverTimeIndexPage in order to pass and kill all mutations, and in doing so I added an extra sectionFixture with entries with different quarters so that I could verify that the sorting by quarter was working properly.

Also, I noticed that also for the building search and the instructor search, the results are displayed with oldest quarter first. For all 3 searches, I believe this is because of the order in which the API returns data, which is why I chose to sort the data when sending it to the SectionsOverTimeTable in the CourseOverTimeIndexPage.

Dev Dokku Link:
https://proj-courses-evanja57-dev.dokku-02.cs.ucsb.edu/
Closes #11 