### PR TITLE
Kai remove course route

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,9 +18,6 @@ import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSche
 import PersonalSchedulesDetailsPage from "main/pages/PersonalSchedules/PersonalSchedulesDetailsPage";
 import SectionSearchesIndexPage from "main/pages/SectionSearches/SectionSearchesIndexPage";
 
-import CoursesIndexPage from "main/pages/Courses/PSCourseIndexPage";
-import CoursesCreatePage from "main/pages/Courses/PSCourseCreatePage";
-
 import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
 import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage";
 
@@ -70,12 +67,6 @@ function App() {
               element={<PersonalSchedulesEditPage />}
             />
 
-            <Route exact path="/courses/list" element={<CoursesIndexPage />} />
-            <Route
-              exact
-              path="/courses/create"
-              element={<CoursesCreatePage />}
-            />
             <Route
               exact
               path="/personalschedules/details/:id"

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -63,14 +63,6 @@ export default function AppNavbar({
                   Personal Schedules
                 </Nav.Link>
               )}
-              {hasRole(currentUser, "ROLE_USER") && (
-                <Nav.Link
-                  href="/courses/list"
-                  data-testid="appnavbar-courses-list"
-                >
-                  Courses
-                </Nav.Link>
-              )}
             </Nav>
 
             <Nav className="mr-auto">

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -201,10 +201,7 @@ describe("AppNavbar tests", () => {
       await screen.findByTestId("appnavbar-personalschedules-list"),
     ).toBeInTheDocument();
 
-    expect(await screen.findByText("Courses")).toBeInTheDocument();
-    expect(
-      await screen.findByTestId("appnavbar-courses-list"),
-    ).toBeInTheDocument();
+
   });
 
   test("renders the Course Description menu correctly", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -200,8 +200,6 @@ describe("AppNavbar tests", () => {
     expect(
       await screen.findByTestId("appnavbar-personalschedules-list"),
     ).toBeInTheDocument();
-
-
   });
 
   test("renders the Course Description menu correctly", async () => {


### PR DESCRIPTION
Removed the courses tab from the navBar. This feature was deemed unnecessary and was removed from the website as the functionality exists elsewhere.

New Navbar
<img width="1619" alt="Screenshot 2024-05-23 at 7 08 11 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/102753513/b78c5286-994a-454a-97b0-c0fbbc391667">

Old Navbar
<img width="1620" alt="Screenshot 2024-05-23 at 7 08 20 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/102753513/039d624f-27c1-4376-aaa9-52f06fa68aa4">


dokku: https://proj-courses-kai-maeda-dev.dokku-02.cs.ucsb.edu/

Closes #4