### PR TITLE
Julia changed react app name to Courses 

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Courses</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Courses",
+  "name": "Courses",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
In files index.html and manifest.json the name React app was changed to courses.

Title of app used to be React App:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/c125a3d8-c18f-4486-a44a-36fad98045c1)

Title of app in tab should now be Courses: 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/026c42ba-16f8-4ae5-8ca5-b86a01696822)

https://proj-jchandev-dev.dokku-02.cs.ucsb.edu/
