### PR TITLE
Adding Increment Pitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,25 @@ To access the swagger API endpoints, use:
 
 * On localhost only: <http://localhost:8080/h2-console>  See also: [docs/h2-console.md](docs/h2-console.md)
 * On Dokku: see: <https://ucsb-cs156.github.io/topics/dokku/postgres_command_line.html>
+
+## Partial pitest runs
+
+This repo has support for partial pitest runs
+
+For example, to run pitest on just one class, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.courses.controllers.PSCourseController
+```
+
+To run pitest on just one package, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.courses.controllers.*
+```
+
+To run full mutation test coverage, as usual, use:
+
+```
+mvn pitest:mutationCoverage
+```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.courses.controllers.P
 To run pitest on just one package, use:
 
 ```
-mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.courses.controllers.*
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.courses.controllers.\*
 ```
 
 To run full mutation test coverage, as usual, use:

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <description>Starter for s22 courses search</description>
     <properties>
         <java.version>17</java.version>
+        <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
     </properties>
     <dependencies>
         <dependency>
@@ -215,7 +216,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                        <param>edu.ucsb.cs156.*</param>
+                         <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>


### PR DESCRIPTION
Edited pom.xml to add incremental pitest runs based on this slack post:
https://ucsb-cs156-s24.slack.com/archives/C06SB2A2U00/p1716606189595369

Can run `mvn pitest:mutationCoverage` on just a single class, or a single package, instead of the entire backend code base.

Example to run on the terminal:
mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.courses.controllers.\*

deployment: https://proj-courses-kmflippo-dev.dokku-02.cs.ucsb.edu

Closes #33