### PR TITLE
Kelly swagger delete with psid and enroll code

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -37,10 +37,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class PSCourseController extends ApiController {
 
-  @Autowired PSCourseRepository coursesRepository;
-  @Autowired PersonalScheduleRepository personalScheduleRepository;
-  @Autowired UCSBCurriculumService ucsbCurriculumService;
-  @Autowired ObjectMapper mapper;
+  @Autowired
+  PSCourseRepository coursesRepository;
+  @Autowired
+  PersonalScheduleRepository personalScheduleRepository;
+  @Autowired
+  UCSBCurriculumService ucsbCurriculumService;
+  @Autowired
+  ObjectMapper mapper;
 
   @Operation(summary = "List all courses (admin)")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -81,10 +85,8 @@ public class PSCourseController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @GetMapping("/admin")
   public PSCourse getCourseById_admin(@Parameter(name = "id") @RequestParam Long id) {
-    PSCourse courses =
-        coursesRepository
-            .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses = coursesRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     return courses;
   }
@@ -94,10 +96,8 @@ public class PSCourseController extends ApiController {
   @GetMapping("/user")
   public PSCourse getCourseById(@Parameter(name = "id") @RequestParam Long id) {
     User currentUser = getCurrentUser().getUser();
-    PSCourse courses =
-        coursesRepository
-            .findByIdAndUser(id, currentUser)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses = coursesRepository.findByIdAndUser(id, currentUser)
+        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     return courses;
   }
@@ -107,14 +107,12 @@ public class PSCourseController extends ApiController {
   @PostMapping("/post")
   public ArrayList<PSCourse> postCourses(
       @Parameter(name = "enrollCd") @RequestParam String enrollCd,
-      @Parameter(name = "psId") @RequestParam Long psId)
-      throws JsonProcessingException {
+      @Parameter(name = "psId") @RequestParam Long psId) throws JsonProcessingException {
     CurrentUser currentUser = getCurrentUser();
     log.info("currentUser={}", currentUser);
 
     PersonalSchedule checkPsId =
-        personalScheduleRepository
-            .findByIdAndUser(psId, currentUser.getUser())
+        personalScheduleRepository.findByIdAndUser(psId, currentUser.getUser())
             .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
 
     String body = ucsbCurriculumService.getAllSections(enrollCd, checkPsId.getQuarter());
@@ -132,7 +130,8 @@ public class PSCourseController extends ApiController {
       if (section.endsWith("00")) {
         String currentEnrollCd = classSection.path("enrollCode").asText();
         enrollCdPrimary = currentEnrollCd;
-        if (hasSecondary) break;
+        if (hasSecondary)
+          break;
       } else {
         hasSecondary = true;
       }
@@ -158,9 +157,8 @@ public class PSCourseController extends ApiController {
       PSCourse savedSecondary = coursesRepository.save(secondary);
       savedCourses.add(savedSecondary);
     } else if (hasSecondary) {
-      throw new IllegalArgumentException(
-          enrollCd
-              + " is for a course with sections; please add a specific section and the lecture will be automatically added");
+      throw new IllegalArgumentException(enrollCd
+          + " is for a course with sections; please add a specific section and the lecture will be automatically added");
     }
 
     PSCourse primary = new PSCourse();
@@ -176,10 +174,8 @@ public class PSCourseController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @DeleteMapping("/admin")
   public Object deleteCourses_Admin(@Parameter(name = "id") @RequestParam Long id) {
-    PSCourse courses =
-        coursesRepository
-            .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses = coursesRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     coursesRepository.delete(courses);
 
@@ -192,15 +188,11 @@ public class PSCourseController extends ApiController {
   public Object deleteCourses(@Parameter(name = "id") @RequestParam Long id)
       throws JsonProcessingException {
     User currentUser = getCurrentUser().getUser();
-    PSCourse psCourse =
-        coursesRepository
-            .findByIdAndUser(id, currentUser)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse psCourse = coursesRepository.findByIdAndUser(id, currentUser)
+        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
     long psId = psCourse.getPsId();
-    PersonalSchedule checkPsId =
-        personalScheduleRepository
-            .findByIdAndUser(psId, currentUser)
-            .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+    PersonalSchedule checkPsId = personalScheduleRepository.findByIdAndUser(psId, currentUser)
+        .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
 
     String body =
         ucsbCurriculumService.getAllSections(psCourse.getEnrollCd(), checkPsId.getQuarter());
@@ -219,22 +211,23 @@ public class PSCourseController extends ApiController {
       String currentEnrollCd = classSection.path("enrollCode").asText();
       Optional<PSCourse> currentPsCourse =
           coursesRepository.findByPsIdAndEnrollCd(psId, currentEnrollCd);
-      if (!currentPsCourse.isPresent()) continue;
+      if (!currentPsCourse.isPresent())
+        continue;
       Optional<Long> idOpt = Optional.of(currentPsCourse.get().getId());
-      if (section.endsWith("00")) primaryId = idOpt;
-      else secondaryId = idOpt;
+      if (section.endsWith("00"))
+        primaryId = idOpt;
+      else
+        secondaryId = idOpt;
       coursesRepository.delete(currentPsCourse.get());
     }
 
     if (primaryId.isPresent() && secondaryId.isPresent()) {
       if (primaryId.get() == id)
-        return genericMessage(
-            "PSCourse with id %s and matching secondary with id %s deleted"
-                .formatted(id, secondaryId.get()));
+        return genericMessage("PSCourse with id %s and matching secondary with id %s deleted"
+            .formatted(id, secondaryId.get()));
       else
-        return genericMessage(
-            "PSCourse with id %s and matching primary with id %s deleted"
-                .formatted(id, primaryId.get()));
+        return genericMessage("PSCourse with id %s and matching primary with id %s deleted"
+            .formatted(id, primaryId.get()));
     }
 
     return genericMessage("PSCourse with id %s deleted".formatted(id));
@@ -243,28 +236,23 @@ public class PSCourseController extends ApiController {
   @Operation(summary = "Delete a course with psid and enroll code (user)")
   @PreAuthorize("hasRole('ROLE_USER')")
   @DeleteMapping("/user/psid")
-  public Object deleteCourses_PSID(
-    @Parameter(name = "enrollCd") @RequestParam String enrollCd,
-    @Parameter(name = "psId") @RequestParam Long psId)
-      throws JsonProcessingException {
+  public Object deleteCourses_PSID(@Parameter(name = "enrollCd") @RequestParam String enrollCd,
+      @Parameter(name = "psId") @RequestParam Long psId) throws JsonProcessingException {
     User currentUser = getCurrentUser().getUser();
 
-    PSCourse psCourse = 
-        coursesRepository
-            .findByPsIdAndEnrollCd(psId, enrollCd)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, "psId", psId, "enrollCode", enrollCd));
+    PSCourse psCourse = coursesRepository.findByPsIdAndEnrollCd(psId, enrollCd).orElseThrow(
+        () -> new EntityNotFoundException(PSCourse.class, "psId", psId, "enrollCode", enrollCd));
     long id = psCourse.getId();
-    PersonalSchedule checkPsId =
-        personalScheduleRepository
-            .findByIdAndUser(psId, currentUser)
-            .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+    PersonalSchedule checkPsId = personalScheduleRepository.findByIdAndUser(psId, currentUser)
+        .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
 
     String body =
         ucsbCurriculumService.getAllSections(psCourse.getEnrollCd(), checkPsId.getQuarter());
     if (body.equals("{\"error\": \"401: Unauthorized\"}")
         || body.equals("{\"error\": \"Enroll code doesn't exist in that quarter.\"}")) {
       coursesRepository.delete(psCourse);
-      return genericMessage("PSCourse with psId %s and enroll code %s deleted".formatted(psId, enrollCd));
+      return genericMessage(
+          "PSCourse with psId %s and enroll code %s deleted".formatted(psId, enrollCd));
     }
 
     Iterator<JsonNode> it = mapper.readTree(body).path("classSections").elements();
@@ -276,25 +264,27 @@ public class PSCourseController extends ApiController {
       String currentEnrollCd = classSection.path("enrollCode").asText();
       Optional<PSCourse> currentPsCourse =
           coursesRepository.findByPsIdAndEnrollCd(psId, currentEnrollCd);
-      if (!currentPsCourse.isPresent()) continue;
+      if (!currentPsCourse.isPresent())
+        continue;
       Optional<Long> idOpt = Optional.of(currentPsCourse.get().getId());
-      if (section.endsWith("00")) primaryId = idOpt;
-      else secondaryId = idOpt;
+      if (section.endsWith("00"))
+        primaryId = idOpt;
+      else
+        secondaryId = idOpt;
       coursesRepository.delete(currentPsCourse.get());
     }
 
     if (primaryId.isPresent() && secondaryId.isPresent()) {
       if (primaryId.get() == id)
-        return genericMessage(
-            "PSCourse with id %s and matching secondary with id %s deleted"
-                .formatted(id, secondaryId.get()));
+        return genericMessage("PSCourse with id %s and matching secondary with id %s deleted"
+            .formatted(id, secondaryId.get()));
       else
-        return genericMessage(
-            "PSCourse with id %s and matching primary with id %s deleted"
-                .formatted(id, primaryId.get()));
+        return genericMessage("PSCourse with id %s and matching primary with id %s deleted"
+            .formatted(id, primaryId.get()));
     }
 
-    return genericMessage("PSCourse with psId %s and enroll code %s deleted".formatted(psId, enrollCd));
+    return genericMessage(
+        "PSCourse with psId %s and enroll code %s deleted".formatted(psId, enrollCd));
   }
 
 
@@ -302,12 +292,10 @@ public class PSCourseController extends ApiController {
   @Operation(summary = "Update a single Course (admin)")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PutMapping("/admin")
-  public PSCourse putCourseById_admin(
-      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid PSCourse incomingCourses) {
-    PSCourse courses =
-        coursesRepository
-            .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+  public PSCourse putCourseById_admin(@Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid PSCourse incomingCourses) {
+    PSCourse courses = coursesRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     courses.setEnrollCd(incomingCourses.getEnrollCd());
     courses.setPsId(incomingCourses.getPsId());
@@ -320,13 +308,11 @@ public class PSCourseController extends ApiController {
   @Operation(summary = "Update a single course (user)")
   @PreAuthorize("hasRole('ROLE_USER')")
   @PutMapping("/user")
-  public PSCourse putCoursesById(
-      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid PSCourse incomingCourses) {
+  public PSCourse putCoursesById(@Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid PSCourse incomingCourses) {
     User currentUser = getCurrentUser().getUser();
-    PSCourse courses =
-        coursesRepository
-            .findByIdAndUser(id, currentUser)
-            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses = coursesRepository.findByIdAndUser(id, currentUser)
+        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     courses.setEnrollCd(incomingCourses.getEnrollCd());
     courses.setPsId(incomingCourses.getPsId());

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -294,7 +294,7 @@ public class PSCourseController extends ApiController {
                 .formatted(id, primaryId.get()));
     }
 
-    return genericMessage("PSCourse with id %s deleted".formatted(id));
+    return genericMessage("PSCourse with psId %s and enroll code %s deleted".formatted(psId, enrollCd));
   }
 
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -37,14 +37,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class PSCourseController extends ApiController {
 
-  @Autowired
-  PSCourseRepository coursesRepository;
-  @Autowired
-  PersonalScheduleRepository personalScheduleRepository;
-  @Autowired
-  UCSBCurriculumService ucsbCurriculumService;
-  @Autowired
-  ObjectMapper mapper;
+  @Autowired PSCourseRepository coursesRepository;
+  @Autowired PersonalScheduleRepository personalScheduleRepository;
+  @Autowired UCSBCurriculumService ucsbCurriculumService;
+  @Autowired ObjectMapper mapper;
 
   @Operation(summary = "List all courses (admin)")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -85,8 +81,10 @@ public class PSCourseController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @GetMapping("/admin")
   public PSCourse getCourseById_admin(@Parameter(name = "id") @RequestParam Long id) {
-    PSCourse courses = coursesRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses =
+        coursesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     return courses;
   }
@@ -96,8 +94,10 @@ public class PSCourseController extends ApiController {
   @GetMapping("/user")
   public PSCourse getCourseById(@Parameter(name = "id") @RequestParam Long id) {
     User currentUser = getCurrentUser().getUser();
-    PSCourse courses = coursesRepository.findByIdAndUser(id, currentUser)
-        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses =
+        coursesRepository
+            .findByIdAndUser(id, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     return courses;
   }
@@ -107,12 +107,14 @@ public class PSCourseController extends ApiController {
   @PostMapping("/post")
   public ArrayList<PSCourse> postCourses(
       @Parameter(name = "enrollCd") @RequestParam String enrollCd,
-      @Parameter(name = "psId") @RequestParam Long psId) throws JsonProcessingException {
+      @Parameter(name = "psId") @RequestParam Long psId)
+      throws JsonProcessingException {
     CurrentUser currentUser = getCurrentUser();
     log.info("currentUser={}", currentUser);
 
     PersonalSchedule checkPsId =
-        personalScheduleRepository.findByIdAndUser(psId, currentUser.getUser())
+        personalScheduleRepository
+            .findByIdAndUser(psId, currentUser.getUser())
             .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
 
     String body = ucsbCurriculumService.getAllSections(enrollCd, checkPsId.getQuarter());
@@ -130,8 +132,7 @@ public class PSCourseController extends ApiController {
       if (section.endsWith("00")) {
         String currentEnrollCd = classSection.path("enrollCode").asText();
         enrollCdPrimary = currentEnrollCd;
-        if (hasSecondary)
-          break;
+        if (hasSecondary) break;
       } else {
         hasSecondary = true;
       }
@@ -157,8 +158,9 @@ public class PSCourseController extends ApiController {
       PSCourse savedSecondary = coursesRepository.save(secondary);
       savedCourses.add(savedSecondary);
     } else if (hasSecondary) {
-      throw new IllegalArgumentException(enrollCd
-          + " is for a course with sections; please add a specific section and the lecture will be automatically added");
+      throw new IllegalArgumentException(
+          enrollCd
+              + " is for a course with sections; please add a specific section and the lecture will be automatically added");
     }
 
     PSCourse primary = new PSCourse();
@@ -174,8 +176,10 @@ public class PSCourseController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @DeleteMapping("/admin")
   public Object deleteCourses_Admin(@Parameter(name = "id") @RequestParam Long id) {
-    PSCourse courses = coursesRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses =
+        coursesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     coursesRepository.delete(courses);
 
@@ -188,11 +192,15 @@ public class PSCourseController extends ApiController {
   public Object deleteCourses(@Parameter(name = "id") @RequestParam Long id)
       throws JsonProcessingException {
     User currentUser = getCurrentUser().getUser();
-    PSCourse psCourse = coursesRepository.findByIdAndUser(id, currentUser)
-        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse psCourse =
+        coursesRepository
+            .findByIdAndUser(id, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
     long psId = psCourse.getPsId();
-    PersonalSchedule checkPsId = personalScheduleRepository.findByIdAndUser(psId, currentUser)
-        .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+    PersonalSchedule checkPsId =
+        personalScheduleRepository
+            .findByIdAndUser(psId, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
 
     String body =
         ucsbCurriculumService.getAllSections(psCourse.getEnrollCd(), checkPsId.getQuarter());
@@ -211,23 +219,22 @@ public class PSCourseController extends ApiController {
       String currentEnrollCd = classSection.path("enrollCode").asText();
       Optional<PSCourse> currentPsCourse =
           coursesRepository.findByPsIdAndEnrollCd(psId, currentEnrollCd);
-      if (!currentPsCourse.isPresent())
-        continue;
+      if (!currentPsCourse.isPresent()) continue;
       Optional<Long> idOpt = Optional.of(currentPsCourse.get().getId());
-      if (section.endsWith("00"))
-        primaryId = idOpt;
-      else
-        secondaryId = idOpt;
+      if (section.endsWith("00")) primaryId = idOpt;
+      else secondaryId = idOpt;
       coursesRepository.delete(currentPsCourse.get());
     }
 
     if (primaryId.isPresent() && secondaryId.isPresent()) {
       if (primaryId.get() == id)
-        return genericMessage("PSCourse with id %s and matching secondary with id %s deleted"
-            .formatted(id, secondaryId.get()));
+        return genericMessage(
+            "PSCourse with id %s and matching secondary with id %s deleted"
+                .formatted(id, secondaryId.get()));
       else
-        return genericMessage("PSCourse with id %s and matching primary with id %s deleted"
-            .formatted(id, primaryId.get()));
+        return genericMessage(
+            "PSCourse with id %s and matching primary with id %s deleted"
+                .formatted(id, primaryId.get()));
     }
 
     return genericMessage("PSCourse with id %s deleted".formatted(id));
@@ -236,15 +243,24 @@ public class PSCourseController extends ApiController {
   @Operation(summary = "Delete a course with psid and enroll code (user)")
   @PreAuthorize("hasRole('ROLE_USER')")
   @DeleteMapping("/user/psid")
-  public Object deleteCourses_PSID(@Parameter(name = "enrollCd") @RequestParam String enrollCd,
-      @Parameter(name = "psId") @RequestParam Long psId) throws JsonProcessingException {
+  public Object deleteCourses_PSID(
+      @Parameter(name = "enrollCd") @RequestParam String enrollCd,
+      @Parameter(name = "psId") @RequestParam Long psId)
+      throws JsonProcessingException {
     User currentUser = getCurrentUser().getUser();
 
-    PSCourse psCourse = coursesRepository.findByPsIdAndEnrollCd(psId, enrollCd).orElseThrow(
-        () -> new EntityNotFoundException(PSCourse.class, "psId", psId, "enrollCode", enrollCd));
+    PSCourse psCourse =
+        coursesRepository
+            .findByPsIdAndEnrollCd(psId, enrollCd)
+            .orElseThrow(
+                () ->
+                    new EntityNotFoundException(
+                        PSCourse.class, "psId", psId, "enrollCode", enrollCd));
     long id = psCourse.getId();
-    PersonalSchedule checkPsId = personalScheduleRepository.findByIdAndUser(psId, currentUser)
-        .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+    PersonalSchedule checkPsId =
+        personalScheduleRepository
+            .findByIdAndUser(psId, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
 
     String body =
         ucsbCurriculumService.getAllSections(psCourse.getEnrollCd(), checkPsId.getQuarter());
@@ -264,38 +280,37 @@ public class PSCourseController extends ApiController {
       String currentEnrollCd = classSection.path("enrollCode").asText();
       Optional<PSCourse> currentPsCourse =
           coursesRepository.findByPsIdAndEnrollCd(psId, currentEnrollCd);
-      if (!currentPsCourse.isPresent())
-        continue;
+      if (!currentPsCourse.isPresent()) continue;
       Optional<Long> idOpt = Optional.of(currentPsCourse.get().getId());
-      if (section.endsWith("00"))
-        primaryId = idOpt;
-      else
-        secondaryId = idOpt;
+      if (section.endsWith("00")) primaryId = idOpt;
+      else secondaryId = idOpt;
       coursesRepository.delete(currentPsCourse.get());
     }
 
     if (primaryId.isPresent() && secondaryId.isPresent()) {
       if (primaryId.get() == id)
-        return genericMessage("PSCourse with id %s and matching secondary with id %s deleted"
-            .formatted(id, secondaryId.get()));
+        return genericMessage(
+            "PSCourse with id %s and matching secondary with id %s deleted"
+                .formatted(id, secondaryId.get()));
       else
-        return genericMessage("PSCourse with id %s and matching primary with id %s deleted"
-            .formatted(id, primaryId.get()));
+        return genericMessage(
+            "PSCourse with id %s and matching primary with id %s deleted"
+                .formatted(id, primaryId.get()));
     }
 
     return genericMessage(
         "PSCourse with psId %s and enroll code %s deleted".formatted(psId, enrollCd));
   }
 
-
-
   @Operation(summary = "Update a single Course (admin)")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PutMapping("/admin")
-  public PSCourse putCourseById_admin(@Parameter(name = "id") @RequestParam Long id,
-      @RequestBody @Valid PSCourse incomingCourses) {
-    PSCourse courses = coursesRepository.findById(id)
-        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+  public PSCourse putCourseById_admin(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid PSCourse incomingCourses) {
+    PSCourse courses =
+        coursesRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     courses.setEnrollCd(incomingCourses.getEnrollCd());
     courses.setPsId(incomingCourses.getPsId());
@@ -308,11 +323,13 @@ public class PSCourseController extends ApiController {
   @Operation(summary = "Update a single course (user)")
   @PreAuthorize("hasRole('ROLE_USER')")
   @PutMapping("/user")
-  public PSCourse putCoursesById(@Parameter(name = "id") @RequestParam Long id,
-      @RequestBody @Valid PSCourse incomingCourses) {
+  public PSCourse putCoursesById(
+      @Parameter(name = "id") @RequestParam Long id, @RequestBody @Valid PSCourse incomingCourses) {
     User currentUser = getCurrentUser().getUser();
-    PSCourse courses = coursesRepository.findByIdAndUser(id, currentUser)
-        .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
+    PSCourse courses =
+        coursesRepository
+            .findByIdAndUser(id, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, id));
 
     courses.setEnrollCd(incomingCourses.getEnrollCd());
     courses.setPsId(incomingCourses.getPsId());

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -240,6 +240,82 @@ public class PSCourseController extends ApiController {
     return genericMessage("PSCourse with id %s deleted".formatted(id));
   }
 
+
+
+
+
+
+
+ 
+  @Operation(summary = "Delete a course with psid and enroll code (user)")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @DeleteMapping("/user/psid")
+  public Object deleteCourses_PSID(
+    @Parameter(name = "enrollCd") @RequestParam String enrollCd,
+    @Parameter(name = "psId") @RequestParam Long psId)
+      throws JsonProcessingException {
+    User currentUser = getCurrentUser().getUser();
+
+    long id = 0;
+    Iterable<PSCourse> courses = coursesRepository.findAllByPsId(psId);
+    for (PSCourse myCourse : courses) {
+
+      if (myCourse.getEnrollCd().equals(enrollCd)) {
+        id = myCourse.getId();
+        break;
+      }
+    } 
+
+    PSCourse psCourse =
+        coursesRepository
+            .findByIdAndUser(id, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PSCourse.class, enrollCd));
+
+    PersonalSchedule checkPsId =
+        personalScheduleRepository
+            .findByIdAndUser(psId, currentUser)
+            .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, psId));
+
+    String body =
+        ucsbCurriculumService.getAllSections(psCourse.getEnrollCd(), checkPsId.getQuarter());
+    if (body.equals("{\"error\": \"401: Unauthorized\"}")
+        || body.equals("{\"error\": \"Enroll code doesn't exist in that quarter.\"}")) {
+      coursesRepository.delete(psCourse);
+      return genericMessage("PSCourse with id %s deleted".formatted(id));
+    }
+
+    Iterator<JsonNode> it = mapper.readTree(body).path("classSections").elements();
+    Optional<Long> primaryId = Optional.empty();
+    Optional<Long> secondaryId = Optional.empty();
+    while (it.hasNext()) {
+      JsonNode classSection = it.next();
+      String section = classSection.path("section").asText();
+      String currentEnrollCd = classSection.path("enrollCode").asText();
+      Optional<PSCourse> currentPsCourse =
+          coursesRepository.findByPsIdAndEnrollCd(psId, currentEnrollCd);
+      if (!currentPsCourse.isPresent()) continue;
+      Optional<Long> idOpt = Optional.of(currentPsCourse.get().getId());
+      if (section.endsWith("00")) primaryId = idOpt;
+      else secondaryId = idOpt;
+      coursesRepository.delete(currentPsCourse.get());
+    }
+
+    if (primaryId.isPresent() && secondaryId.isPresent()) {
+      if (primaryId.get() == id)
+        return genericMessage(
+            "PSCourse with id %s and matching secondary with id %s deleted"
+                .formatted(id, secondaryId.get()));
+      else
+        return genericMessage(
+            "PSCourse with id %s and matching primary with id %s deleted"
+                .formatted(id, primaryId.get()));
+    }
+
+    return genericMessage("PSCourse with id %s deleted".formatted(id));
+  }
+
+
+
   @Operation(summary = "Update a single Course (admin)")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PutMapping("/admin")

--- a/src/main/java/edu/ucsb/cs156/courses/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/courses/errors/EntityNotFoundException.java
@@ -5,7 +5,19 @@ public class EntityNotFoundException extends RuntimeException {
     super("%s with id %s not found".formatted(entityType.getSimpleName(), id.toString()));
   }
 
-  public EntityNotFoundException(Class<?> entityType, String fieldOneName, Object fieldOneValue, String fieldTwoName, Object fieldTwoValue) {
-    super("%s with %s %s and %s %s not found".formatted(entityType.getSimpleName(), fieldOneName, fieldOneValue.toString(), fieldTwoName, fieldTwoValue.toString()));
+  public EntityNotFoundException(
+      Class<?> entityType,
+      String fieldOneName,
+      Object fieldOneValue,
+      String fieldTwoName,
+      Object fieldTwoValue) {
+    super(
+        "%s with %s %s and %s %s not found"
+            .formatted(
+                entityType.getSimpleName(),
+                fieldOneName,
+                fieldOneValue.toString(),
+                fieldTwoName,
+                fieldTwoValue.toString()));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/courses/errors/EntityNotFoundException.java
@@ -4,4 +4,8 @@ public class EntityNotFoundException extends RuntimeException {
   public EntityNotFoundException(Class<?> entityType, Object id) {
     super("%s with id %s not found".formatted(entityType.getSimpleName(), id.toString()));
   }
+
+  public EntityNotFoundException(Class<?> entityType, String fieldOneName, Object fieldOneValue, String fieldTwoName, Object fieldTwoValue) {
+    super("%s with %s %s and %s %s not found".formatted(entityType.getSimpleName(), fieldOneName, fieldOneValue.toString(), fieldTwoName, fieldTwoValue.toString()));
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -749,7 +749,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
 
-  // New test --- delete this comment after
   @WithMockUser(roles = {"USER"})
   @Test
   public void
@@ -787,8 +786,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
   }
 
-  // End of new test ---- delete this comment after
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void
@@ -824,8 +821,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
-
-  // start of new test 2 (delete later)
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -863,8 +858,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
   }
-
-  // end of new test 2
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -904,8 +897,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
-
-  // start of new test 3
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -947,8 +938,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
   }
 
-  // end of new test 3
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_course__primary_with_no_secondary()
@@ -986,8 +975,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
-
-  // start of new test 4
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1027,8 +1014,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
   }
-
-  // end of new test 4
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1073,8 +1058,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals(
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
-
-  // start of new test 5
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1121,8 +1104,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
 
-  // end of new test 5
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_course__secondary_with_primary()
@@ -1166,8 +1147,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 2 and matching primary with id 1 deleted", json.get("message"));
   }
 
-  // start of new test 6
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_by_psid_course__secondary_with_primary()
@@ -1185,7 +1164,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     PSCourse primary = PSCourse.builder().enrollCd("63370").psId(1L).user(u).id(1L).build();
     PSCourse secondary = PSCourse.builder().enrollCd("63388").psId(1L).user(u).id(2L).build();
 
-    // when(coursesRepository.findByIdAndUser(eq(2L), eq(u))).thenReturn(Optional.of(secondary));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
     when(ucsbCurriculumService.getAllSections(eq("63388"), eq("20221")))
         .thenReturn(SectionFixtures.SECTION_JSON_CMPSC100);
@@ -1210,8 +1188,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 2 and matching primary with id 1 deleted", json.get("message"));
   }
-
-  // end of new test 6
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1259,8 +1235,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
 
-  // start of new test 7
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void
@@ -1279,7 +1253,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     PSCourse primary = PSCourse.builder().enrollCd("08292").psId(1L).user(u).id(1L).build();
     PSCourse secondary = PSCourse.builder().enrollCd("08300").psId(1L).user(u).id(2L).build();
 
-    // when(coursesRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(primary));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
     when(ucsbCurriculumService.getAllSections(eq("08292"), eq("20221")))
         .thenReturn(SectionFixtures.SECTION_JSON_CMPSC156_UNEXPECTED);
@@ -1308,8 +1281,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
 
-  // end of new test 7
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_course_that_does_not_exist() throws Exception {
@@ -1330,14 +1301,11 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 not found", json.get("message"));
   }
 
-  // start of new test 8
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_by_psid_course_that_does_not_exist()
       throws Exception {
     // arrange
-    // User u = currentUserService.getCurrentUser().getUser();
     when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08292"))).thenReturn(Optional.empty());
 
     // act
@@ -1352,8 +1320,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enrollCode 08292 not found", json.get("message"));
   }
-
-  // end of new test 8
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1380,7 +1346,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PersonalSchedule with id 1 not found", json.get("message"));
   }
 
-  // start of new test 9
   @WithMockUser(roles = {"USER"})
   @Test
   public void
@@ -1407,8 +1372,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PersonalSchedule with id 1 not found", json.get("message"));
   }
 
-  // end of new test 9
-
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__cannot_delete_delete_belonging_to_another_user()
@@ -1432,13 +1395,11 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 31 not found", json.get("message"));
   }
 
-  // start of new test 10
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__cannot_delete_by_psid_delete_belonging_to_another_user()
       throws Exception {
     // arrange
-    // User u = currentUserService.getCurrentUser().getUser();
     User otherUser = User.builder().id(98L).build();
     PSCourse ps1 = PSCourse.builder().enrollCd("08250").psId(13L).user(otherUser).id(31L).build();
     when(coursesRepository.findById(eq(31L))).thenReturn(Optional.of(ps1));
@@ -1455,8 +1416,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 13 and enrollCode 08250 not found", json.get("message"));
   }
-
-  // end of new test 10
 
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -749,8 +749,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
 
-
-
   // New test --- delete this comment after
   @WithMockUser(roles = {"USER"})
   @Test
@@ -769,7 +767,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
             .build();
     PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
 
-    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896")))
+        .thenReturn(Optional.of(primary));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
     when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
         .thenReturn("{\"error\": \"Enroll code doesn't exist in that quarter.\"}");
@@ -787,7 +786,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
   }
-
 
   // End of new test ---- delete this comment after
 
@@ -827,10 +825,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
 
-
-
   // start of new test 2 (delete later)
-  
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void
@@ -848,7 +844,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
             .build();
     PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
 
-    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896")))
+        .thenReturn(Optional.of(primary));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
     when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
         .thenReturn("{\"error\": \"401: Unauthorized\"}");
@@ -908,9 +905,9 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
 
-// start of new test 3
+  // start of new test 3
 
-@WithMockUser(roles = {"USER"})
+  @WithMockUser(roles = {"USER"})
   @Test
   public void
       api_courses__user_logged_in__delete_by_psid_course__ucsb_api__primary_not_found__treat_as_primary()
@@ -927,7 +924,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
             .build();
     PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
 
-    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896")))
+        .thenReturn(Optional.of(primary));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
     when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
         .thenReturn(SectionFixtures.SECTION_JSON_CMPSC291A_UNEXPECTED);
@@ -947,7 +945,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(coursesRepository, times(1)).delete(primary);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
-  } 
+  }
+
   // end of new test 3
 
   @WithMockUser(roles = {"USER"})
@@ -989,7 +988,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
   }
 
   // start of new test 4
-  
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_by_psid_course__primary_with_no_secondary()
@@ -1006,7 +1005,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
             .build();
     PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
 
-    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896")))
+        .thenReturn(Optional.of(primary));
     when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
         .thenReturn(SectionFixtures.SECTION_JSON_CMPSC291A);
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
@@ -1026,7 +1026,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(coursesRepository, times(1)).delete(primary);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
-  } 
+  }
+
   // end of new test 4
 
   @WithMockUser(roles = {"USER"})
@@ -1074,7 +1075,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
   }
 
   // start of new test 5
-  
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_by_psid_course__primary_with_secondary()
@@ -1092,7 +1093,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     PSCourse primary = PSCourse.builder().enrollCd("63370").psId(1L).user(u).id(1L).build();
     PSCourse secondary = PSCourse.builder().enrollCd("63388").psId(1L).user(u).id(2L).build();
 
-    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63370"))).thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63370")))
+        .thenReturn(Optional.of(primary));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
     when(ucsbCurriculumService.getAllSections(eq("63370"), eq("20221")))
         .thenReturn(SectionFixtures.SECTION_JSON_CMPSC100);
@@ -1117,7 +1119,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals(
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
-  } 
+  }
+
   // end of new test 5
 
   @WithMockUser(roles = {"USER"})
@@ -1163,8 +1166,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 2 and matching primary with id 1 deleted", json.get("message"));
   }
 
-  //start of new test 6
-  
+  // start of new test 6
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_by_psid_course__secondary_with_primary()
@@ -1206,7 +1209,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(coursesRepository, times(1)).delete(secondary);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 2 and matching primary with id 1 deleted", json.get("message"));
-  } 
+  }
+
   // end of new test 6
 
   @WithMockUser(roles = {"USER"})
@@ -1256,11 +1260,12 @@ public class PSCourseControllerTests extends ControllerTestCase {
   }
 
   // start of new test 7
-   
+
   @WithMockUser(roles = {"USER"})
   @Test
-  public void api_courses__user_logged_in__delete_by_psid_course__primary_with_multiple_secondaries()
-      throws Exception {
+  public void
+      api_courses__user_logged_in__delete_by_psid_course__primary_with_multiple_secondaries()
+          throws Exception {
     // arrange
     User u = currentUserService.getCurrentUser().getUser();
     PersonalSchedule ps =
@@ -1302,8 +1307,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals(
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
-  // end of new test 7
 
+  // end of new test 7
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1326,10 +1331,11 @@ public class PSCourseControllerTests extends ControllerTestCase {
   }
 
   // start of new test 8
-  
+
   @WithMockUser(roles = {"USER"})
   @Test
-  public void api_courses__user_logged_in__delete_by_psid_course_that_does_not_exist() throws Exception {
+  public void api_courses__user_logged_in__delete_by_psid_course_that_does_not_exist()
+      throws Exception {
     // arrange
     // User u = currentUserService.getCurrentUser().getUser();
     when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08292"))).thenReturn(Optional.empty());
@@ -1345,7 +1351,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(coursesRepository, times(1)).findByPsIdAndEnrollCd(1L, "08292");
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 1 and enrollCode 08292 not found", json.get("message"));
-  }  
+  }
+
   // end of new test 8
 
   @WithMockUser(roles = {"USER"})
@@ -1371,7 +1378,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PersonalSchedule with id 1 not found", json.get("message"));
-  } 
+  }
 
   // start of new test 9
   @WithMockUser(roles = {"USER"})
@@ -1382,7 +1389,8 @@ public class PSCourseControllerTests extends ControllerTestCase {
     // arrange
     User u = currentUserService.getCurrentUser().getUser();
     PSCourse course = PSCourse.builder().enrollCd("00000").psId(1L).user(u).id(1L).build();
-    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("00000"))).thenReturn(Optional.of(course));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("00000")))
+        .thenReturn(Optional.of(course));
     when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.empty());
 
     // act
@@ -1397,9 +1405,9 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PersonalSchedule with id 1 not found", json.get("message"));
-  } 
-  // end of new test 9
+  }
 
+  // end of new test 9
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1430,7 +1438,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
   public void api_courses__user_logged_in__cannot_delete_by_psid_delete_belonging_to_another_user()
       throws Exception {
     // arrange
-    //User u = currentUserService.getCurrentUser().getUser();
+    // User u = currentUserService.getCurrentUser().getUser();
     User otherUser = User.builder().id(98L).build();
     PSCourse ps1 = PSCourse.builder().enrollCd("08250").psId(13L).user(otherUser).id(31L).build();
     when(coursesRepository.findById(eq(31L))).thenReturn(Optional.of(ps1));
@@ -1447,6 +1455,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with psId 13 and enrollCode 08250 not found", json.get("message"));
   }
+
   // end of new test 10
 
   @WithMockUser(roles = {"ADMIN", "USER"})

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -931,7 +931,6 @@ public class PSCourseControllerTests extends ControllerTestCase {
             .andReturn();
 
     // assert
-    // verify(coursesRepository, times(1)).findByIdAndUser(1L, u);
     verify(coursesRepository, times(2)).findByPsIdAndEnrollCd(1L, "08896");
     verify(coursesRepository, times(1)).delete(primary);
     Map<String, Object> json = responseToJson(response);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -749,6 +749,48 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
 
+
+
+  // New test --- delete this comment after
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void
+      api_courses__user_logged_in__delete_by_psid_course__ucsb_api__enroll_code_does_not_exist_error__treat_as_primary()
+          throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
+
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
+        .thenReturn("{\"error\": \"Enroll code doesn't exist in that quarter.\"}");
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=08896&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(1)).findByPsIdAndEnrollCd(1L, "08896");
+    verify(coursesRepository, times(1)).delete(primary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
+  }
+
+
+  // End of new test ---- delete this comment after
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void
@@ -784,6 +826,48 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
+
+
+
+  // start of new test 2 (delete later)
+  
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void
+      api_courses__user_logged_in__delete_by_psid_course__ucsb_api__unauthorized_error__treat_as_primary()
+          throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
+
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
+        .thenReturn("{\"error\": \"401: Unauthorized\"}");
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=08896&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(1)).findByPsIdAndEnrollCd(1L, "08896");
+    verify(coursesRepository, times(1)).delete(primary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
+  }
+
+  // end of new test 2
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -824,6 +908,48 @@ public class PSCourseControllerTests extends ControllerTestCase {
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
 
+// start of new test 3
+
+@WithMockUser(roles = {"USER"})
+  @Test
+  public void
+      api_courses__user_logged_in__delete_by_psid_course__ucsb_api__primary_not_found__treat_as_primary()
+          throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
+
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
+        .thenReturn(SectionFixtures.SECTION_JSON_CMPSC291A_UNEXPECTED);
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896")))
+        .thenReturn(Optional.of(primary));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=08896&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    // verify(coursesRepository, times(1)).findByIdAndUser(1L, u);
+    verify(coursesRepository, times(2)).findByPsIdAndEnrollCd(1L, "08896");
+    verify(coursesRepository, times(1)).delete(primary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
+  } 
+  // end of new test 3
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_course__primary_with_no_secondary()
@@ -861,6 +987,47 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 1 deleted", json.get("message"));
   }
+
+  // start of new test 4
+  
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void api_courses__user_logged_in__delete_by_psid_course__primary_with_no_secondary()
+      throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("08896").psId(1L).user(u).id(1L).build();
+
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896"))).thenReturn(Optional.of(primary));
+    when(ucsbCurriculumService.getAllSections(eq("08896"), eq("20221")))
+        .thenReturn(SectionFixtures.SECTION_JSON_CMPSC291A);
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08896")))
+        .thenReturn(Optional.of(primary));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=08896&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(2)).findByPsIdAndEnrollCd(1L, "08896");
+    verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
+    verify(coursesRepository, times(1)).delete(primary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("PSCourse with psId 1 and enroll code 08896 deleted", json.get("message"));
+  } 
+  // end of new test 4
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -906,6 +1073,53 @@ public class PSCourseControllerTests extends ControllerTestCase {
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
 
+  // start of new test 5
+  
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void api_courses__user_logged_in__delete_by_psid_course__primary_with_secondary()
+      throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("63370").psId(1L).user(u).id(1L).build();
+    PSCourse secondary = PSCourse.builder().enrollCd("63388").psId(1L).user(u).id(2L).build();
+
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63370"))).thenReturn(Optional.of(primary));
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(ucsbCurriculumService.getAllSections(eq("63370"), eq("20221")))
+        .thenReturn(SectionFixtures.SECTION_JSON_CMPSC100);
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63370")))
+        .thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63388")))
+        .thenReturn(Optional.of(secondary));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=63370&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(2)).findByPsIdAndEnrollCd(1L, "63370");
+    verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
+    verify(ucsbCurriculumService, times(1)).getAllSections("63370", "20221");
+    verify(coursesRepository, times(1)).delete(primary);
+    verify(coursesRepository, times(1)).delete(secondary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals(
+        "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
+  } 
+  // end of new test 5
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_course__secondary_with_primary()
@@ -948,6 +1162,52 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 2 and matching primary with id 1 deleted", json.get("message"));
   }
+
+  //start of new test 6
+  
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void api_courses__user_logged_in__delete_by_psid_course__secondary_with_primary()
+      throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("63370").psId(1L).user(u).id(1L).build();
+    PSCourse secondary = PSCourse.builder().enrollCd("63388").psId(1L).user(u).id(2L).build();
+
+    // when(coursesRepository.findByIdAndUser(eq(2L), eq(u))).thenReturn(Optional.of(secondary));
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(ucsbCurriculumService.getAllSections(eq("63388"), eq("20221")))
+        .thenReturn(SectionFixtures.SECTION_JSON_CMPSC100);
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63370")))
+        .thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("63388")))
+        .thenReturn(Optional.of(secondary));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=63388&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(2)).findByPsIdAndEnrollCd(1L, "63388");
+    verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
+    verify(ucsbCurriculumService, times(1)).getAllSections("63388", "20221");
+    verify(coursesRepository, times(1)).delete(primary);
+    verify(coursesRepository, times(1)).delete(secondary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("PSCourse with id 2 and matching primary with id 1 deleted", json.get("message"));
+  } 
+  // end of new test 6
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -995,6 +1255,56 @@ public class PSCourseControllerTests extends ControllerTestCase {
         "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
   }
 
+  // start of new test 7
+   
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void api_courses__user_logged_in__delete_by_psid_course__primary_with_multiple_secondaries()
+      throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    PersonalSchedule ps =
+        PersonalSchedule.builder()
+            .name("Test")
+            .description("Test")
+            .quarter("20221")
+            .user(u)
+            .id(1L)
+            .build();
+    PSCourse primary = PSCourse.builder().enrollCd("08292").psId(1L).user(u).id(1L).build();
+    PSCourse secondary = PSCourse.builder().enrollCd("08300").psId(1L).user(u).id(2L).build();
+
+    // when(coursesRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(primary));
+    when(personalScheduleRepository.findByIdAndUser(eq(1L), eq(u))).thenReturn(Optional.of(ps));
+    when(ucsbCurriculumService.getAllSections(eq("08292"), eq("20221")))
+        .thenReturn(SectionFixtures.SECTION_JSON_CMPSC156_UNEXPECTED);
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08292")))
+        .thenReturn(Optional.of(primary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08300")))
+        .thenReturn(Optional.of(secondary));
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08318"))).thenReturn(Optional.empty());
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08326"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=08292&psId=1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(2)).findByPsIdAndEnrollCd(1L, "08292");
+    verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
+    verify(ucsbCurriculumService, times(1)).getAllSections("08292", "20221");
+    verify(coursesRepository, times(1)).delete(primary);
+    verify(coursesRepository, times(1)).delete(secondary);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals(
+        "PSCourse with id 1 and matching secondary with id 2 deleted", json.get("message"));
+  }
+  // end of new test 7
+
+
   @WithMockUser(roles = {"USER"})
   @Test
   public void api_courses__user_logged_in__delete_course_that_does_not_exist() throws Exception {
@@ -1014,6 +1324,29 @@ public class PSCourseControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("PSCourse with id 1 not found", json.get("message"));
   }
+
+  // start of new test 8
+  /*
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void api_courses__user_logged_in__delete_by_psid_course_that_does_not_exist() throws Exception {
+    // arrange
+    User u = currentUserService.getCurrentUser().getUser();
+    when(coursesRepository.findByPsIdAndEnrollCd(eq(1L), eq("08292"))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/courses/user/psid?enrollCd=08292&psId=1").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(coursesRepository, times(1)).findByIdAndUser(1L, u);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("PSCourse with psid 1 and enrollCode 08292 not found", json.get("message"));
+  }  */
+  // end of new test 8
 
   @WithMockUser(roles = {"USER"})
   @Test
@@ -1038,7 +1371,9 @@ public class PSCourseControllerTests extends ControllerTestCase {
     verify(personalScheduleRepository, times(1)).findByIdAndUser(1L, u);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PersonalSchedule with id 1 not found", json.get("message"));
-  }
+  } 
+
+
 
   @WithMockUser(roles = {"USER"})
   @Test


### PR DESCRIPTION
Added swagger delete endpoint for PSCourses to use enroll code and psId to delete a course from a personal schedule instead of id.

When run on local host you can see a new swagger endpoint:
<img width="1465" alt="image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/46656629/89f7d5e2-1ff8-4352-9ba8-dd395556a9d9">

This swagger endpoint adds another way to delete a course from a personal schedule using psId and enroll Code
<img width="1445" alt="image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/46656629/075a1f2f-f65f-47e6-9707-094048b1e134">


Added endpoint to PSCoursesController.java, added tests to test new endpoint in PSCoursesControllerTests.java, and added new EntityNotFoundException in EntityNotFoundException.java in order to throw an exception in a different format than just using id.

dokku deployment: https://proj-courses-kmflippo-dev.dokku-02.cs.ucsb.edu/
Note: the dokku deployed, but Swagger is not accessible from dokku because we use the mongodb for that.

Closes #36 