### PR TITLE
Julia Refactored Table UI with different colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,14 +16,19 @@ code {
 }
 
 .btn-primary,
-.btn-primary:hover{
+.btn-primary:hover {
   background-color: #2280bf;
 }
 .btn-primary:focus {
-  background-color: #18335d ;
+  background-color: #18335d;
   border-color: #34859b;
 }
 
 .table-hover tbody tr.hovered-row {
-  background-color: rgba(174, 203, 223, .001) !important; /* Custom hover color */
+  background-color: rgba(
+    174,
+    203,
+    223,
+    0.001
+  ) !important; /* Custom hover color */
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,8 +16,14 @@ code {
 }
 
 .btn-primary,
-.btn-primary:hover,
+.btn-primary:hover{
+  background-color: #2280bf;
+}
 .btn-primary:focus {
-  background-color: #34859b;
+  background-color: #18335d ;
   border-color: #34859b;
+}
+
+.table-hover tbody tr.hovered-row {
+  background-color: rgba(174, 203, 223, .001) !important; /* Custom hover color */
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,12 +23,3 @@ code {
   background-color: #18335d;
   border-color: #34859b;
 }
-
-.table-hover tbody tr.hovered-row {
-  background-color: rgba(
-    174,
-    203,
-    223,
-    0.001
-  ) !important; /* Custom hover color */
-}

--- a/frontend/src/main/components/SectionsInstructorTableBase.js
+++ b/frontend/src/main/components/SectionsInstructorTableBase.js
@@ -41,9 +41,7 @@ export default function SectionsInstructorTableBase({
           prepareRow(row);
           return (
             <>
-              <tr 
-                {...row.getRowProps()}
-              >
+              <tr {...row.getRowProps()}>
                 {row.cells.map((cell, _index) => {
                   return (
                     <td

--- a/frontend/src/main/components/SectionsInstructorTableBase.js
+++ b/frontend/src/main/components/SectionsInstructorTableBase.js
@@ -21,7 +21,7 @@ export default function SectionsInstructorTableBase({
     );
 
   return (
-    <Table {...getTableProps()} striped bordered hover>
+    <Table {...getTableProps()} bordered hover>
       <thead>
         {headerGroups.map((headerGroup) => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -41,7 +41,9 @@ export default function SectionsInstructorTableBase({
           prepareRow(row);
           return (
             <>
-              <tr {...row.getRowProps()}>
+              <tr 
+                {...row.getRowProps()}
+              >
                 {row.cells.map((cell, _index) => {
                   return (
                     <td
@@ -52,11 +54,11 @@ export default function SectionsInstructorTableBase({
                         background: isSection(
                           data[cell.row.index].section.section,
                         )
-                          ? "#9dbfbe"
-                          : "#34859b",
+                          ? "#ffffff"
+                          : "#e3ebfc",
                         color: isSection(data[cell.row.index].section.section)
                           ? "#000000"
-                          : "#effcf4",
+                          : "#4a4f4f",
                         fontWeight: isSection(
                           data[cell.row.index].section.section,
                         )

--- a/frontend/src/main/components/SectionsOverTimeTableBase.js
+++ b/frontend/src/main/components/SectionsOverTimeTableBase.js
@@ -52,15 +52,15 @@ export default function SectionsOverTimeTableBase({
                         // Stryker disable next-line ObjectLiteral
                         style={{
                           background: cell.isGrouped
-                            ? "#34859b"
+                            ? "#cedefa"
                             : cell.isAggregated
-                            ? "#34859b"
+                            ? "#cedefa"
                             : "#9dbfbe",
                           color: cell.isGrouped
-                            ? "#effcf4"
+                            ? "#4a4f4f"
                             : cell.isAggregated
-                            ? "#effcf4"
-                            : "#000000",
+                            ? "#4a4f4f"
+                            : "#4a4f4f",
                           fontWeight: cell.isGrouped
                             ? "bold"
                             : cell.isAggregated

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment} from "react";
 import { useTable, useGroupBy, useExpanded } from "react-table";
 import { Table } from "react-bootstrap";
 
@@ -22,10 +22,7 @@ export default function SectionsTableBase({
       useGroupBy,
       useExpanded,
     );
-  const [hoveredRowIndex, setHoveredRowIndex] = useState(null);
 
-  const handleMouseEnter = (index) => setHoveredRowIndex(index);
-  const handleMouseLeave = () => setHoveredRowIndex(null);
   return (
     <Table {...getTableProps()} bordered hover className="table-hover">
       <thead key="thead">
@@ -45,7 +42,6 @@ export default function SectionsTableBase({
       <tbody {...getTableBodyProps()} key="tbody">
         {rows.map((row, i) => {
           prepareRow(row);
-          const isHovered = i === hoveredRowIndex;
           const rowStyle = {
             background: i % 2 === 0 ? "#e3ebfc" : "#ffffff",
           };
@@ -54,10 +50,6 @@ export default function SectionsTableBase({
               {row.cells[0].isGrouped ||
               (!row.cells[0].isGrouped && row.allCells[3].value) ? (
                 <tr
-                  {...row.getRowProps()}
-                  onMouseEnter={() => handleMouseEnter(i)}
-                  onMouseLeave={handleMouseLeave}
-                  className={isHovered ? "hovered-row" : ""}
                   style={rowStyle}
                 >
                   {row.cells.map((cell, _index) => {

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -22,10 +22,10 @@ export default function SectionsTableBase({
       useGroupBy,
       useExpanded,
     );
-    const [hoveredRowIndex, setHoveredRowIndex] = useState(null);
+  const [hoveredRowIndex, setHoveredRowIndex] = useState(null);
 
-    const handleMouseEnter = (index) => setHoveredRowIndex(index);
-    const handleMouseLeave = () => setHoveredRowIndex(null);
+  const handleMouseEnter = (index) => setHoveredRowIndex(index);
+  const handleMouseLeave = () => setHoveredRowIndex(null);
   return (
     <Table {...getTableProps()} bordered hover className="table-hover">
       <thead key="thead">
@@ -47,7 +47,7 @@ export default function SectionsTableBase({
           prepareRow(row);
           const isHovered = i === hoveredRowIndex;
           const rowStyle = {
-            background: i % 2 === 0 ? "#e3ebfc" : "#ffffff" ,
+            background: i % 2 === 0 ? "#e3ebfc" : "#ffffff",
           };
           return (
             <Fragment key={`row-${i}`}>
@@ -57,7 +57,7 @@ export default function SectionsTableBase({
                   {...row.getRowProps()}
                   onMouseEnter={() => handleMouseEnter(i)}
                   onMouseLeave={handleMouseLeave}
-                  className={isHovered ? 'hovered-row' : ''}
+                  className={isHovered ? "hovered-row" : ""}
                   style={rowStyle}
                 >
                   {row.cells.map((cell, _index) => {
@@ -67,7 +67,10 @@ export default function SectionsTableBase({
                         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                         // Stryker disable next-line ObjectLiteral
                         style={{
-                          background: cell.isGrouped || cell.isAggregated ? "inherit" : null,
+                          background:
+                            cell.isGrouped || cell.isAggregated
+                              ? "inherit"
+                              : null,
 
                           color: cell.isGrouped
                             ? "#4a4f4f"

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -57,11 +57,11 @@ export default function SectionsTableBase({
                         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                         // Stryker disable next-line ObjectLiteral
                         style={{
-                          background:
-                            cell.isGrouped || cell.isAggregated
-                              ? "inherit"
-                              : null,
-
+                          background: cell.isGrouped
+                            ? "inherit"
+                            : cell.isAggregated
+                            ? "inherit"
+                            : null,
                           color: cell.isGrouped
                             ? "#4a4f4f"
                             : cell.isAggregated

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
 import { useTable, useGroupBy, useExpanded } from "react-table";
 import { Table } from "react-bootstrap";
 
@@ -22,9 +22,12 @@ export default function SectionsTableBase({
       useGroupBy,
       useExpanded,
     );
+    const [hoveredRowIndex, setHoveredRowIndex] = useState(null);
 
+    const handleMouseEnter = (index) => setHoveredRowIndex(index);
+    const handleMouseLeave = () => setHoveredRowIndex(null);
   return (
-    <Table {...getTableProps()} striped bordered hover>
+    <Table {...getTableProps()} bordered hover className="table-hover">
       <thead key="thead">
         {headerGroups.map((headerGroup) => (
           <tr {...headerGroup.getHeaderGroupProps()}>
@@ -42,11 +45,21 @@ export default function SectionsTableBase({
       <tbody {...getTableBodyProps()} key="tbody">
         {rows.map((row, i) => {
           prepareRow(row);
+          const isHovered = i === hoveredRowIndex;
+          const rowStyle = {
+            background: i % 2 === 0 ? "#e3ebfc" : "#ffffff" ,
+          };
           return (
             <Fragment key={`row-${i}`}>
               {row.cells[0].isGrouped ||
               (!row.cells[0].isGrouped && row.allCells[3].value) ? (
-                <tr {...row.getRowProps()}>
+                <tr
+                  {...row.getRowProps()}
+                  onMouseEnter={() => handleMouseEnter(i)}
+                  onMouseLeave={handleMouseLeave}
+                  className={isHovered ? 'hovered-row' : ''}
+                  style={rowStyle}
+                >
                   {row.cells.map((cell, _index) => {
                     return (
                       <td
@@ -54,16 +67,13 @@ export default function SectionsTableBase({
                         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                         // Stryker disable next-line ObjectLiteral
                         style={{
-                          background: cell.isGrouped
-                            ? "#34859b"
-                            : cell.isAggregated
-                            ? "#34859b"
-                            : "#9dbfbe",
+                          background: cell.isGrouped || cell.isAggregated ? "inherit" : null,
+
                           color: cell.isGrouped
-                            ? "#effcf4"
+                            ? "#4a4f4f"
                             : cell.isAggregated
-                            ? "#effcf4"
-                            : "#000000",
+                            ? "#4a4f4f"
+                            : "#4a4f4f",
                           fontWeight: cell.isGrouped
                             ? "bold"
                             : cell.isAggregated

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,4 +1,4 @@
-import React, { Fragment} from "react";
+import React, { Fragment } from "react";
 import { useTable, useGroupBy, useExpanded } from "react-table";
 import { Table } from "react-bootstrap";
 
@@ -49,9 +49,7 @@ export default function SectionsTableBase({
             <Fragment key={`row-${i}`}>
               {row.cells[0].isGrouped ||
               (!row.cells[0].isGrouped && row.allCells[3].value) ? (
-                <tr
-                  style={rowStyle}
-                >
+                <tr style={rowStyle}>
                   {row.cells.map((cell, _index) => {
                     return (
                       <td

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -146,7 +146,7 @@ describe("SectionsTableBase tests", () => {
       screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
     ).toHaveAttribute(
       "style",
-      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
+      "color: rgb(74, 79, 79); font-weight: bold;",
     );
   });
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -147,15 +147,34 @@ describe("SectionsTableBase tests", () => {
     ).toHaveAttribute("style", "color: rgb(74, 79, 79); font-weight: bold;");
   });
 
-  test("renders the second row with a white background correctly", async () => {
+  test("renders rows with alternating background colors correctly", async () => {
     render(
       <SectionsTableBase columns={columns} data={fiveSections} group={false} />,
     );
-    const secondRowCell = screen.getByTestId(
-      "testid-cell-row-1-col-courseInfo.courseId",
-    );
-    const secondRow = secondRowCell.closest("tr");
-    const style = window.getComputedStyle(secondRow);
-    expect(style.backgroundColor).toBe("rgb(255, 255, 255)");
+  
+    // Check the background color of the first few rows
+    const rows = [
+      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId").closest('tr'),
+      screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId").closest('tr'),
+      screen.getByTestId("testid-cell-row-2-col-courseInfo.courseId").closest('tr'),
+      screen.getByTestId("testid-cell-row-3-col-courseInfo.courseId").closest('tr'),
+      screen.getByTestId("testid-cell-row-4-col-courseInfo.courseId").closest('tr')
+    ];
+  
+    // Expected background colors
+    const expectedBackgroundColors = [
+      "rgb(227, 235, 252)", // #e3ebfc in RGB format
+      "rgb(255, 255, 255)", // #ffffff in RGB format
+      "rgb(227, 235, 252)", // #e3ebfc in RGB format
+      "rgb(255, 255, 255)", // #ffffff in RGB format
+      "rgb(227, 235, 252)"  // #e3ebfc in RGB format
+    ];
+  
+    // Verify the background colors for each row
+    rows.forEach((row, index) => {
+      const style = window.getComputedStyle(row);
+      expect(style.backgroundColor).toBe(expectedBackgroundColors[index]);
+    });
   });
+  
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -160,24 +160,13 @@ describe("SectionsTableBase tests", () => {
       screen
         .getByTestId("testid-cell-row-1-col-courseInfo.courseId")
         .closest("tr"),
-      screen
-        .getByTestId("testid-cell-row-2-col-courseInfo.courseId")
-        .closest("tr"),
-      screen
-        .getByTestId("testid-cell-row-3-col-courseInfo.courseId")
-        .closest("tr"),
-      screen
-        .getByTestId("testid-cell-row-4-col-courseInfo.courseId")
-        .closest("tr"),
+    
     ];
 
     // Expected background colors
     const expectedBackgroundColors = [
       "rgb(227, 235, 252)", // #e3ebfc in RGB format
       "rgb(255, 255, 255)", // #ffffff in RGB format
-      "rgb(227, 235, 252)", // #e3ebfc in RGB format
-      "rgb(255, 255, 255)", // #ffffff in RGB format
-      "rgb(227, 235, 252)", // #e3ebfc in RGB format
     ];
 
     // Verify the background colors for each row

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -149,7 +149,7 @@ describe("SectionsTableBase tests", () => {
 
   test("renders rows with alternating background colors correctly", async () => {
     render(
-      <SectionsTableBase columns={columns} data={fiveSections} group={false} />,
+      <SectionsTableBase columns={columns} data={gigaSections} group={false} />,
     );
 
     // Check the background color of the first few rows
@@ -160,11 +160,18 @@ describe("SectionsTableBase tests", () => {
       screen
         .getByTestId("testid-cell-row-1-col-courseInfo.courseId")
         .closest("tr"),
-    
+      screen
+        .getByTestId("testid-cell-row-2-col-courseInfo.courseId")
+        .closest("tr"),
+      screen
+        .getByTestId("testid-cell-row-3-col-courseInfo.courseId")
+        .closest("tr"),
     ];
 
     // Expected background colors
     const expectedBackgroundColors = [
+      "rgb(227, 235, 252)", // #e3ebfc in RGB format
+      "rgb(255, 255, 255)", // #ffffff in RGB format
       "rgb(227, 235, 252)", // #e3ebfc in RGB format
       "rgb(255, 255, 255)", // #ffffff in RGB format
     ];

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -144,9 +144,6 @@ describe("SectionsTableBase tests", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
-    ).toHaveAttribute(
-      "style",
-      "color: rgb(74, 79, 79); font-weight: bold;",
-    );
+    ).toHaveAttribute("style", "color: rgb(74, 79, 79); font-weight: bold;");
   });
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -151,30 +151,39 @@ describe("SectionsTableBase tests", () => {
     render(
       <SectionsTableBase columns={columns} data={fiveSections} group={false} />,
     );
-  
+
     // Check the background color of the first few rows
     const rows = [
-      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId").closest('tr'),
-      screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId").closest('tr'),
-      screen.getByTestId("testid-cell-row-2-col-courseInfo.courseId").closest('tr'),
-      screen.getByTestId("testid-cell-row-3-col-courseInfo.courseId").closest('tr'),
-      screen.getByTestId("testid-cell-row-4-col-courseInfo.courseId").closest('tr')
+      screen
+        .getByTestId("testid-cell-row-0-col-courseInfo.courseId")
+        .closest("tr"),
+      screen
+        .getByTestId("testid-cell-row-1-col-courseInfo.courseId")
+        .closest("tr"),
+      screen
+        .getByTestId("testid-cell-row-2-col-courseInfo.courseId")
+        .closest("tr"),
+      screen
+        .getByTestId("testid-cell-row-3-col-courseInfo.courseId")
+        .closest("tr"),
+      screen
+        .getByTestId("testid-cell-row-4-col-courseInfo.courseId")
+        .closest("tr"),
     ];
-  
+
     // Expected background colors
     const expectedBackgroundColors = [
       "rgb(227, 235, 252)", // #e3ebfc in RGB format
       "rgb(255, 255, 255)", // #ffffff in RGB format
       "rgb(227, 235, 252)", // #e3ebfc in RGB format
       "rgb(255, 255, 255)", // #ffffff in RGB format
-      "rgb(227, 235, 252)"  // #e3ebfc in RGB format
+      "rgb(227, 235, 252)", // #e3ebfc in RGB format
     ];
-  
+
     // Verify the background colors for each row
     rows.forEach((row, index) => {
       const style = window.getComputedStyle(row);
       expect(style.backgroundColor).toBe(expectedBackgroundColors[index]);
     });
   });
-  
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -146,4 +146,16 @@ describe("SectionsTableBase tests", () => {
       screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
     ).toHaveAttribute("style", "color: rgb(74, 79, 79); font-weight: bold;");
   });
+
+  test("renders the second row with a white background correctly", async () => {
+    render(
+      <SectionsTableBase columns={columns} data={fiveSections} group={false} />,
+    );
+    const secondRowCell = screen.getByTestId(
+      "testid-cell-row-1-col-courseInfo.courseId",
+    );
+    const secondRow = secondRowCell.closest("tr");
+    const style = window.getComputedStyle(secondRow);
+    expect(style.backgroundColor).toBe("rgb(255, 255, 255)");
+  });
 });


### PR DESCRIPTION
Changed files SectionsInstructorTableBase, SectionsOverTimeTableBase, SectionsTableBase and index.css to change color theme.

Before, the color scheme made it hard to see when hovering and wasn't that asthetic:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/bc769305-5f5a-4782-a2f2-8d9138e73ab4)

**Also changed button color:** 
unclicked:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/1881d3f4-affa-4cbe-893c-c38edfeccfbd)
clicked:
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/80e3f7a3-b45d-48c3-8db4-52f6eb05c6b4)

**For main search:** 
Now it looks like this with alternating color for more distinction: 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/c5614379-b9ce-4484-afa2-8889ee6b58fb)
And if hovering over it, it turns grey: 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/842aa99e-0a32-4698-9979-c2aabc33a8b5)

Can still tell which ones are sections and which are not from the bolded names: 
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/080dd677-392e-4281-9f30-c045e6e413b7)

**For search by instructor:**
Color scheme was changed and now lectures are blue while sections are white
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/c8f297ac-34f8-45c9-8c9b-c859b98e1c4e)

**For search by location:**
color scheme also fixed to be alternating
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/5281d5d0-33de-4eb1-aa0b-9a0b5223151e)

**For course history:** 
changed color scheme here too
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/60370842/ef604df4-3e18-4f4a-a586-eac8fa166498)

Dokku: https://proj-jchandev-dev.dokku-02.cs.ucsb.edu

