### PR TITLE
Evan grade history page

### DIFF
--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -5,6 +5,7 @@ import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable";
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
+import GradeHistoryGraphs from "main/components/GradeHistory/GradeHistoryGraph";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -26,6 +27,33 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  const courseId = moreDetails?.courseId.trim() || "";
+
+  let subjectArea = "";
+  let trimmedCourseNumber = "";
+
+  // Splitting on two spaces allows for courses with multiple word subject areas (i.e. AS AM) to be recognized
+  if (courseId) {
+    const splitArray = courseId.split("  ");
+    subjectArea = splitArray[0];
+    trimmedCourseNumber = splitArray[splitArray.length - 1].trim();
+  }
+
+  // Fetch Grade History Data
+  const { data: gradeHistory } = useBackend(
+    [
+      `/api/gradehistory/search?subjectArea=${subjectArea}&courseNumber=${trimmedCourseNumber}`,
+    ],
+    {
+      method: "GET",
+      url: "/api/gradehistory/search",
+      params: {
+        subjectArea: subjectArea,
+        courseNumber: trimmedCourseNumber,
+      },
+    },
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -37,6 +65,7 @@ export default function CourseDetailsIndexPage() {
 
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
+        {gradeHistory && <GradeHistoryGraphs gradeHistory={gradeHistory} />}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -9,6 +9,7 @@ import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexP
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { personalSectionsFixtures } from "fixtures/personalSectionsFixtures";
+import { oneQuarterCourse } from "fixtures/gradeHistoryFixtures";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -35,6 +36,37 @@ jest.mock("react-router-dom", () => {
     },
   };
 });
+
+class ResizeObserver {
+    constructor(callback) {
+      this.callback = callback;
+    }
+    observe() {
+      // Mock implementation of the observe method
+    }
+    unobserve() {
+      // Mock implementation of the unobserve method
+    }
+    disconnect() {
+      // Mock implementation of the disconnect method
+    }
+  }
+  
+  window.ResizeObserver = ResizeObserver;
+
+  jest.mock("recharts", () => {
+    const OriginalModule = jest.requireActual("recharts");
+  
+    return {
+      ...OriginalModule,
+      ResponsiveContainer: ({ height, children }) => (
+        <OriginalModule.ResponsiveContainer width={800} height={height}>
+          {children}
+        </OriginalModule.ResponsiveContainer>
+      ),
+    };
+  });
+
 describe("Course Details Index Page tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
   beforeEach(() => {
@@ -56,6 +88,11 @@ describe("Course Details Index Page tests", () => {
         params: { qtr: "20221", enrollCode: "06619" },
       })
       .reply(200, personalSectionsFixtures.singleSection);
+    axiosMock
+      .onGet("/api/gradehistory/search", {
+        params: { subjectArea: "CHEM", courseNumber: "184" },
+      })
+      .reply(200, oneQuarterCourse);
   });
 
   const queryClient = new QueryClient();
@@ -77,11 +114,11 @@ describe("Course Details Index Page tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    // await waitFor(() => {
+
     expect(
       screen.getByText("Course Details for CHEM 184 W22"),
     ).toBeInTheDocument();
-    // });
+
     expect(screen.getByText("Enroll Code")).toBeInTheDocument();
     expect(screen.getByText("06619")).toBeInTheDocument();
     expect(screen.getByText("Section")).toBeInTheDocument();
@@ -96,5 +133,17 @@ describe("Course Details Index Page tests", () => {
     expect(screen.getByText("T R")).toBeInTheDocument();
     expect(screen.getByText("Time")).toBeInTheDocument();
     expect(screen.getByText("2:00 PM - 3:15 PM")).toBeInTheDocument();
+  });
+
+ test("Calls grade history api correctly and displays correct information", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseDetailsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("Fall 2009 - GONZALEZ T F")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -38,34 +38,34 @@ jest.mock("react-router-dom", () => {
 });
 
 class ResizeObserver {
-    constructor(callback) {
-      this.callback = callback;
-    }
-    observe() {
-      // Mock implementation of the observe method
-    }
-    unobserve() {
-      // Mock implementation of the unobserve method
-    }
-    disconnect() {
-      // Mock implementation of the disconnect method
-    }
+  constructor(callback) {
+    this.callback = callback;
   }
-  
-  window.ResizeObserver = ResizeObserver;
+  observe() {
+    // Mock implementation of the observe method
+  }
+  unobserve() {
+    // Mock implementation of the unobserve method
+  }
+  disconnect() {
+    // Mock implementation of the disconnect method
+  }
+}
 
-  jest.mock("recharts", () => {
-    const OriginalModule = jest.requireActual("recharts");
-  
-    return {
-      ...OriginalModule,
-      ResponsiveContainer: ({ height, children }) => (
-        <OriginalModule.ResponsiveContainer width={800} height={height}>
-          {children}
-        </OriginalModule.ResponsiveContainer>
-      ),
-    };
-  });
+window.ResizeObserver = ResizeObserver;
+
+jest.mock("recharts", () => {
+  const OriginalModule = jest.requireActual("recharts");
+
+  return {
+    ...OriginalModule,
+    ResponsiveContainer: ({ height, children }) => (
+      <OriginalModule.ResponsiveContainer width={800} height={height}>
+        {children}
+      </OriginalModule.ResponsiveContainer>
+    ),
+  };
+});
 
 describe("Course Details Index Page tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
@@ -135,7 +135,7 @@ describe("Course Details Index Page tests", () => {
     expect(screen.getByText("2:00 PM - 3:15 PM")).toBeInTheDocument();
   });
 
- test("Calls grade history api correctly and displays correct information", async () => {
+  test("Calls grade history api correctly and displays correct information", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>


### PR DESCRIPTION
In this PR, I added my grade history graph to the course details index page, viewable after pressing the little 'i' for more information about a course. This PR is unfortunately not from main, as it entirely relies on the previous feature of having the gradeHistoryGraph component. This component shows a graph on the course details page for every previous offering of the course, sorted by most recent first.
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/bef26082-c522-4b65-afa7-e1a058cb156f)
In order to pass the paramaters to the `/api/gradehistory/search` api call, I used the output from the `/api/sections/sectionsearch` to ensure that the correct class data is searched for. I could have also done this by adding parameters to the CounrseDetailsIndexPage call, but I chose to keep it the same as to avoid adding complexity and changing more files.

The changes that aren't in #45 include `CourseDetailsIndexPage.js` and  `CourseDetailsIndexPage.test.js`

Dokku Link:
https://proj-courses-evanja57-dev.dokku-02.cs.ucsb.edu/

Closes #2 