### PR TITLE
Evan-BUG-Fixing Instructor search output order

### DIFF
--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -40,7 +40,11 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsInstructorTable sections={courseJSON} />
+        <SectionsInstructorTable
+          sections={courseJSON.sort((a, b) =>
+            b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+          )}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
@@ -7,7 +7,10 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { threeSections } from "fixtures/sectionFixtures";
+import {
+  threeSections,
+  differentQuarterSections,
+} from "fixtures/sectionFixtures";
 import { allTheSubjects } from "fixtures/subjectFixtures";
 import userEvent from "@testing-library/user-event";
 
@@ -88,5 +91,58 @@ describe("CourseOverTimeInstructorIndexPage tests", () => {
     });
 
     expect(screen.getByText("ECE 1A")).toBeInTheDocument();
+  });
+
+  test("passes sorted sections to SectionsOverTimeTable", async () => {
+    // Mock the response of the API call with differentQuarterSections data
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    axiosMock
+      .onGet("/api/public/courseovertime/instructorsearch")
+      .reply(200, differentQuarterSections);
+
+    const spy = jest.spyOn(
+      require("main/components/Sections/SectionsInstructorTable"),
+      "default",
+    );
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeInstructorIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20222");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20222");
+    const enterInstructor = screen.getByLabelText("Instructor Name");
+    userEvent.type(enterInstructor, "CONRAD");
+    const selectCheckbox = screen.getByTestId(
+      "CourseOverTimeInstructorSearchForm-checkbox",
+    );
+    userEvent.click(selectCheckbox);
+
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeInTheDocument();
+    userEvent.click(submitButton);
+
+    axiosMock.resetHistory();
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Check that SectionsOverTimeTable received the sorted sections data
+    const sortedSections = differentQuarterSections.sort((a, b) =>
+      b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      { sections: sortedSections },
+      expect.anything(),
+    );
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
In this PR, I noticed that after doing #11 , the output for the instructor search page was also not sorted by most recent quarter first, as shown below. 
# Old behavior
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/98f86e63-aa78-49a0-8e7c-91a28555c38f)

# New Behavior
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/227135af-3f3a-492b-a824-195211258adc)

I have now ensured that this output will be sorted in the Instructor search page in order of newest to oldest.

Dokku Dev Link:
https://proj-courses-evanja57-dev.dokku-02.cs.ucsb.edu/

Closes #48 