### PR TITLE
Evan-BUG: Fixing location history output order

### DIFF
--- a/frontend/src/fixtures/buildingFixtures.js
+++ b/frontend/src/fixtures/buildingFixtures.js
@@ -146,6 +146,105 @@ export const coursesInLib = [
   },
 ];
 
+export const coursesInLibDifferentDate = [
+  {
+    _id: {
+      timestamp: 1684366765,
+      date: 1684366765000,
+    },
+    courseInfo: {
+      quarter: "20201",
+      courseId: "CHEM    184  -1",
+      title: "CHEM LITERATURE",
+      description:
+        "Lectures and exercises on the literature and other information resources of use in chemistry.",
+    },
+    section: {
+      enrollCode: "06619",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 19,
+      maxEnroll: 24,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: null,
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: ["CHEM    284  0100"],
+      timeLocations: [
+        {
+          room: "1312",
+          building: "LIB",
+          roomCapacity: null,
+          days: " T R   ",
+          beginTime: "14:00",
+          endTime: "15:15",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "HUBER C F",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+  {
+    _id: {
+      timestamp: 1684366772,
+      date: 1684366772000,
+    },
+    courseInfo: {
+      quarter: "20222",
+      courseId: "CHEM    284  -1",
+      title: "CHEMICAL LITERATURE",
+      description:
+        "Lectures and exercises on the literature and other   information resources of use in chemistry.",
+    },
+    section: {
+      enrollCode: "06817",
+      section: "0100",
+      session: null,
+      classClosed: null,
+      courseCancelled: null,
+      gradingOptionCode: null,
+      enrolledTotal: 2,
+      maxEnroll: 5,
+      secondaryStatus: null,
+      departmentApprovalRequired: false,
+      instructorApprovalRequired: false,
+      restrictionLevel: null,
+      restrictionMajor: null,
+      restrictionMajorPass: null,
+      restrictionMinor: null,
+      restrictionMinorPass: null,
+      concurrentCourses: ["CHEM    184  0100"],
+      timeLocations: [
+        {
+          room: "1312",
+          building: "LIB",
+          roomCapacity: null,
+          days: " T R   ",
+          beginTime: "14:00",
+          endTime: "15:15",
+        },
+      ],
+      instructors: [
+        {
+          instructor: "HUBER C F",
+          functionCode: "Teaching and in charge",
+        },
+      ],
+    },
+  },
+];
+
 export const oneBuilding = [["ARTS", "Arts Building"]];
 
 export const threeBuildings = [

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage.js
@@ -39,7 +39,11 @@ export default function CourseOverTimeBuildingsIndexPage() {
         <CourseOverTimeBuildingsSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} />
+        <SectionsTable
+          sections={courseJSON.sort((a, b) =>
+            b.courseInfo.quarter.localeCompare(a.courseInfo.quarter),
+          )}
+        />
       </div>
     </BasicLayout>
   );


### PR DESCRIPTION
In this PR, I sorted the output displayed on the location history search page in order to order it from newest to oldest. I decided to do this after seeing #11 , and realizing that this page also runs into this issue.
# Previous Behavior
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/75eb0b49-f1df-403b-be66-b090fb0b7c28)
# Fixed Behavior
![image](https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/114618731/7af970de-ae59-4ca0-a160-6e184eb8b600)

I had to add an additional fixture in `buildingFixtures.js` in order to test the sorted output.

Dev Dokku:
https://proj-courses-evanja57-dev.dokku-02.cs.ucsb.edu/

Closes #50 