### PR TITLE
Kelly - Added delete button for Sections in Personal Schedule Details Page

### DIFF
--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -5,7 +5,6 @@ import {
   cellToAxiosParamsDelete,
   onDeleteSuccess,
 } from "main/utils/PersonalSectionsUtils";
-import { hasRole } from "main/utils/currentUser";
 import {
   convertToFraction,
   formatInstructors,
@@ -13,8 +12,9 @@ import {
   formatTime,
 } from "main/utils/sectionUtils.js";
 
-export default function PersonalSectionsTable({ personalSections , currentUser }) {
-  // Stryker disable all : hard to test for query caching
+export default function PersonalSectionsTable({ personalSections, personalSchedule, showButtons = true, }) {
+  console.log(personalSchedule);
+ // Stryker disable all : hard to test for query caching
  const deleteMutation = useBackendMutation(
   cellToAxiosParamsDelete,
   { onSuccess: onDeleteSuccess },
@@ -23,9 +23,20 @@ export default function PersonalSectionsTable({ personalSections , currentUser }
 // Stryker restore all
 
 // Stryker disable next-line all : TODO try to make a good test for this
+// const deleteCallback = async (cell) => {
+//   deleteMutation.mutate(cell);
+// };
+
+// Stryker disable all : TODO try to make a good test for this
 const deleteCallback = async (cell) => {
-  deleteMutation.mutate(cell);
+  console.log(cell);
+  const psId = 3;
+  const enrollCd = "00653";
+  console.log(psId);
+  console.log(enrollCd);
+  deleteMutation.mutate(enrollCd, psId);
 };
+// Stryker restore all
 
   const columns = [
     {
@@ -72,16 +83,14 @@ const deleteCallback = async (cell) => {
       accessor: (row) => formatInstructors(row.classSections[0].instructors),
       id: "instructor",
     },
-  ];
+  ]; 
 
-  const columnsIfUser = [
+  const buttonColumns = [
     ...columns,
     ButtonColumn("Delete", "danger", deleteCallback, "PersonalSectionsTable"),
   ];
-
-  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
-    ? columnsIfUser
-    : columns;
+  
+  const columnsToDisplay = showButtons ? buttonColumns : columns;
 
   const testid = "PersonalSectionsTable";
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -25,23 +25,10 @@ export default function PersonalSectionsTable({
     [],
   );
   // Stryker restore all
-  console.log(psId);
-  // Stryker disable next-line all : TODO try to make a good test for this
-  // const deleteCallback = async (cell) => {
-  //   deleteMutation.mutate(cell);
-  // };
 
   // Stryker disable all : TODO try to make a good test for this
   const deleteCallback = async (cell) => {
-    console.log(cell);
-    console.log(typeof cell);
-    console.log("MyPsid 1 " + psId);
-    console.log(
-      "Enroll code from details " +
-        cell["row"]["values"]["classSections[0].enrollCode"],
-    );
     deleteMutation.mutate({ cell: cell, psId: psId });
-    console.log("MyPsid 2 " + psId);
   };
   // Stryker restore all
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -13,30 +13,37 @@ import {
 } from "main/utils/sectionUtils.js";
 import { hasRole } from "main/utils/currentUser";
 
-export default function PersonalSectionsTable({ personalSections, psId, currentUser }) {
- // Stryker disable all : hard to test for query caching
- const deleteMutation = useBackendMutation(
-  cellToAxiosParamsDelete,
-  { onSuccess: onDeleteSuccess },
-  [],
-);
-// Stryker restore all
-console.log(psId);
-// Stryker disable next-line all : TODO try to make a good test for this
-// const deleteCallback = async (cell) => {
-//   deleteMutation.mutate(cell);
-// };
+export default function PersonalSectionsTable({
+  personalSections,
+  psId,
+  currentUser,
+}) {
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    [],
+  );
+  // Stryker restore all
+  console.log(psId);
+  // Stryker disable next-line all : TODO try to make a good test for this
+  // const deleteCallback = async (cell) => {
+  //   deleteMutation.mutate(cell);
+  // };
 
-// Stryker disable all : TODO try to make a good test for this
-const deleteCallback = async (cell) => {
-  console.log(cell);
-  console.log(typeof cell);
-  console.log("MyPsid 1 " + psId);
-  console.log("Enroll code from details " + cell["row"]["values"]["classSections[0].enrollCode"]);
-  deleteMutation.mutate({cell: cell, psId: psId});
-  console.log("MyPsid 2 " + psId);
-};
-// Stryker restore all
+  // Stryker disable all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    console.log(cell);
+    console.log(typeof cell);
+    console.log("MyPsid 1 " + psId);
+    console.log(
+      "Enroll code from details " +
+        cell["row"]["values"]["classSections[0].enrollCode"],
+    );
+    deleteMutation.mutate({ cell: cell, psId: psId });
+    console.log("MyPsid 2 " + psId);
+  };
+  // Stryker restore all
 
   const columns = [
     {
@@ -83,13 +90,13 @@ const deleteCallback = async (cell) => {
       accessor: (row) => formatInstructors(row.classSections[0].instructors),
       id: "instructor",
     },
-  ]; 
+  ];
 
   const columnsIfUser = [
     ...columns,
     ButtonColumn("Delete", "danger", deleteCallback, "PersonalSectionsTable"),
   ];
-  
+
   const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
     ? columnsIfUser
     : columns;

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -11,8 +11,9 @@ import {
   formatLocation,
   formatTime,
 } from "main/utils/sectionUtils.js";
+import { hasRole } from "main/utils/currentUser";
 
-export default function PersonalSectionsTable({ personalSections, psId, showButtons = true }) {
+export default function PersonalSectionsTable({ personalSections, psId, currentUser }) {
  // Stryker disable all : hard to test for query caching
  const deleteMutation = useBackendMutation(
   cellToAxiosParamsDelete,
@@ -84,12 +85,14 @@ const deleteCallback = async (cell) => {
     },
   ]; 
 
-  const buttonColumns = [
+  const columnsIfUser = [
     ...columns,
     ButtonColumn("Delete", "danger", deleteCallback, "PersonalSectionsTable"),
   ];
   
-  const columnsToDisplay = showButtons ? buttonColumns : columns;
+  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
+    ? columnsIfUser
+    : columns;
 
   const testid = "PersonalSectionsTable";
 

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -1,5 +1,11 @@
 import React from "react";
-import OurTable from "main/components/OurTable";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/PersonalSectionsUtils";
+import { hasRole } from "main/utils/currentUser";
 import {
   convertToFraction,
   formatInstructors,
@@ -7,7 +13,20 @@ import {
   formatTime,
 } from "main/utils/sectionUtils.js";
 
-export default function PersonalSectionsTable({ personalSections }) {
+export default function PersonalSectionsTable({ personalSections , currentUser }) {
+  // Stryker disable all : hard to test for query caching
+ const deleteMutation = useBackendMutation(
+  cellToAxiosParamsDelete,
+  { onSuccess: onDeleteSuccess },
+  [],
+);
+// Stryker restore all
+
+// Stryker disable next-line all : TODO try to make a good test for this
+const deleteCallback = async (cell) => {
+  deleteMutation.mutate(cell);
+};
+
   const columns = [
     {
       Header: "Course ID",
@@ -55,9 +74,16 @@ export default function PersonalSectionsTable({ personalSections }) {
     },
   ];
 
-  const testid = "PersonalSectionsTable";
+  const columnsIfUser = [
+    ...columns,
+    ButtonColumn("Delete", "danger", deleteCallback, "PersonalSectionsTable"),
+  ];
 
-  const columnsToDisplay = columns;
+  const columnsToDisplay = hasRole(currentUser, "ROLE_USER")
+    ? columnsIfUser
+    : columns;
+
+  const testid = "PersonalSectionsTable";
 
   return (
     <OurTable

--- a/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
+++ b/frontend/src/main/components/PersonalSections/PersonalSectionsTable.js
@@ -12,8 +12,7 @@ import {
   formatTime,
 } from "main/utils/sectionUtils.js";
 
-export default function PersonalSectionsTable({ personalSections, personalSchedule, showButtons = true, }) {
-  console.log(personalSchedule);
+export default function PersonalSectionsTable({ personalSections, psId, showButtons = true }) {
  // Stryker disable all : hard to test for query caching
  const deleteMutation = useBackendMutation(
   cellToAxiosParamsDelete,
@@ -21,7 +20,7 @@ export default function PersonalSectionsTable({ personalSections, personalSchedu
   [],
 );
 // Stryker restore all
-
+console.log(psId);
 // Stryker disable next-line all : TODO try to make a good test for this
 // const deleteCallback = async (cell) => {
 //   deleteMutation.mutate(cell);
@@ -30,11 +29,11 @@ export default function PersonalSectionsTable({ personalSections, personalSchedu
 // Stryker disable all : TODO try to make a good test for this
 const deleteCallback = async (cell) => {
   console.log(cell);
-  const psId = 3;
-  const enrollCd = "00653";
-  console.log(psId);
-  console.log(enrollCd);
-  deleteMutation.mutate(enrollCd, psId);
+  console.log(typeof cell);
+  console.log("MyPsid 1 " + psId);
+  console.log("Enroll code from details " + cell["row"]["values"]["classSections[0].enrollCode"]);
+  deleteMutation.mutate({cell: cell, psId: psId});
+  console.log("MyPsid 2 " + psId);
 };
 // Stryker restore all
 

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -59,9 +59,11 @@ export default function PersonalSchedulesDetailsPage() {
         <p>
           <h2>Sections in Personal Schedule</h2>
           {personalSection && (
-            <PersonalSectionsTable personalSections={personalSection}
-            psId={id} 
-            currentUser={currentUser}/>
+            <PersonalSectionsTable
+              personalSections={personalSection}
+              psId={id}
+              currentUser={currentUser}
+            />
           )}
         </p>
         {createButton()}

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -4,9 +4,11 @@ import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSc
 import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
 import { useBackend, _useBackendMutation } from "main/utils/useBackend";
 import { Button } from "react-bootstrap";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function PersonalSchedulesDetailsPage() {
   let { id } = useParams();
+  const currentUser = useCurrentUser();
 
   const {
     data: personalSchedule,
@@ -55,10 +57,11 @@ export default function PersonalSchedulesDetailsPage() {
           />
         )}
         <p>
-          <h2>Sections in Personal Schedule 88</h2>
+          <h2>Sections in Personal Schedule</h2>
           {personalSection && (
             <PersonalSectionsTable personalSections={personalSection}
-            psId={id} />
+            psId={id} 
+            currentUser={currentUser}/>
           )}
         </p>
         {createButton()}

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -55,9 +55,10 @@ export default function PersonalSchedulesDetailsPage() {
           />
         )}
         <p>
-          <h2>Sections in Personal Schedule</h2>
+          <h2>Sections in Personal Schedule 88</h2>
           {personalSection && (
-            <PersonalSectionsTable personalSections={personalSection} />
+            <PersonalSectionsTable personalSections={personalSection}
+            psId={id} />
           )}
         </p>
         {createButton()}

--- a/frontend/src/main/utils/PersonalSectionsUtils.js
+++ b/frontend/src/main/utils/PersonalSectionsUtils.js
@@ -6,7 +6,6 @@ export function onDeleteSuccess(message) {
 }
 
 export function cellToAxiosParamsDelete({ cell: cell, psId: psId }) {
-  console.log("PS identifier " + psId);
   return {
     url: "/api/courses/user/psid",
     method: "DELETE",

--- a/frontend/src/main/utils/PersonalSectionsUtils.js
+++ b/frontend/src/main/utils/PersonalSectionsUtils.js
@@ -5,13 +5,13 @@ export function onDeleteSuccess(message) {
   toast(message);
 }
 
-export function cellToAxiosParamsDelete(cell) {
+export function cellToAxiosParamsDelete(enrollCd, psId) {
   return {
-    url: "/api/courses/use/psid",
+    url: "/api/courses/user/psid",
     method: "DELETE",
     params: {
-      psId: cell.row.values.psId,
-      enrollCd: cell.row.values.enrollCd
+      enrollCd: enrollCd,
+      psId: psId
     },
   };
 }

--- a/frontend/src/main/utils/PersonalSectionsUtils.js
+++ b/frontend/src/main/utils/PersonalSectionsUtils.js
@@ -5,13 +5,14 @@ export function onDeleteSuccess(message) {
   toast(message);
 }
 
-export function cellToAxiosParamsDelete(enrollCd, psId) {
+export function cellToAxiosParamsDelete({cell: cell, psId: psId}) {
+    console.log("PS identifier " + psId);
   return {
     url: "/api/courses/user/psid",
     method: "DELETE",
     params: {
-      enrollCd: enrollCd,
-      psId: psId
+      enrollCd: cell.row.values["classSections[0].enrollCode"],
+      psId: psId,
     },
   };
 }

--- a/frontend/src/main/utils/PersonalSectionsUtils.js
+++ b/frontend/src/main/utils/PersonalSectionsUtils.js
@@ -5,8 +5,8 @@ export function onDeleteSuccess(message) {
   toast(message);
 }
 
-export function cellToAxiosParamsDelete({cell: cell, psId: psId}) {
-    console.log("PS identifier " + psId);
+export function cellToAxiosParamsDelete({ cell: cell, psId: psId }) {
+  console.log("PS identifier " + psId);
   return {
     url: "/api/courses/user/psid",
     method: "DELETE",

--- a/frontend/src/main/utils/PersonalSectionsUtils.js
+++ b/frontend/src/main/utils/PersonalSectionsUtils.js
@@ -5,7 +5,7 @@ export function onDeleteSuccess(message) {
   toast(message);
 }
 
-export function cellToAxiosParamsDelete({ cell: cell, psId: psId }) {
+export function cellToAxiosParamsDelete({ cell, psId }) {
   return {
     url: "/api/courses/user/psid",
     method: "DELETE",

--- a/frontend/src/main/utils/PersonalSectionsUtils.js
+++ b/frontend/src/main/utils/PersonalSectionsUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/courses/use/psid",
+    method: "DELETE",
+    params: {
+      psId: cell.row.values.psId,
+      enrollCd: cell.row.values.enrollCd
+    },
+  };
+}

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -159,7 +159,6 @@ describe("UserTable tests", () => {
     expect(deleteButton).toHaveClass("btn-danger");
   });
 
-
   test("Delete button calls delete callback for ordinary user", async () => {
     const testId = "PersonalSectionsTable";
     const currentUser = currentUserFixtures.userOnly;

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -177,7 +177,7 @@ describe("UserTable tests", () => {
     );
 
     expect(
-      await screen.getByTestId(`${testId}-cell-row-0-col-courseId`),
+      await screen.findByTestId(`${testId}-cell-row-0-col-courseId`),
     ).toHaveTextContent("ECE 1A");
 
     const deleteButton = screen.getByTestId(

--- a/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
+++ b/frontend/src/tests/components/PersonalSections/PersonalSectionsTable.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -69,11 +69,16 @@ describe("UserTable tests", () => {
   });
 
   test("Has the expected column headers and content", async () => {
+    const currentUser = currentUserFixtures.userOnly;
+    const psId = 1;
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSectionsTable
             personalSections={personalSectionsFixtures.threePersonalSections}
+            psId={psId}
+            currentUser={currentUser}
           />
         </MemoryRouter>
       </QueryClientProvider>,
@@ -146,5 +151,43 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-instructor`),
     ).toHaveTextContent("STEPHANSON B, BUCKWALTER J");
+
+    const deleteButton = screen.getByTestId(
+      `PersonalSectionsTable-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+
+  test("Delete button calls delete callback for ordinary user", async () => {
+    const testId = "PersonalSectionsTable";
+    const currentUser = currentUserFixtures.userOnly;
+    const psId = 1;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSectionsTable
+            personalSections={personalSectionsFixtures.threePersonalSections}
+            psId={psId}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.getByTestId(`${testId}-cell-row-0-col-courseId`),
+    ).toHaveTextContent("ECE 1A");
+
+    const deleteButton = screen.getByTestId(
+      `PersonalSectionsTable-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -148,6 +148,12 @@ describe("PersonalSchedulesDetailsPage tests", () => {
     expect(
       screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-instructor`),
     ).toHaveTextContent("WANG L C");
+
+    const deleteButton = screen.getByTestId(
+      `PersonalSectionsTable-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
   });
 
   test("renders 'Back' button", () => {

--- a/frontend/src/tests/utils/PersonalSectionsUtils.test.js
+++ b/frontend/src/tests/utils/PersonalSectionsUtils.test.js
@@ -42,7 +42,7 @@ import {
   
         // assert
         expect(result).toEqual({
-          url: "/api/courses/user",
+          url: "/api/courses/user/psid",
           method: "DELETE",
           params: { enrollCd: "03452",
           psId: 3 },

--- a/frontend/src/tests/utils/PersonalSectionsUtils.test.js
+++ b/frontend/src/tests/utils/PersonalSectionsUtils.test.js
@@ -1,53 +1,53 @@
 import {
-    onDeleteSuccess,
-    cellToAxiosParamsDelete,
-  } from "main/utils/PersonalSectionsUtils";
-  import mockConsole from "jest-mock-console";
-  
-  const mockToast = jest.fn();
-  jest.mock("react-toastify", () => {
-    const originalModule = jest.requireActual("react-toastify");
-    return {
-      __esModule: true,
-      ...originalModule,
-      toast: (x) => mockToast(x),
-    };
-  });
-  
-  describe("CoursesUtils", () => {
-    describe("onDeleteSuccess", () => {
-      test("It puts the message on console.log and in a toast", () => {
-        // arrange
-        const restoreConsole = mockConsole();
-  
-        // act
-        onDeleteSuccess("abc");
-  
-        // assert
-        expect(mockToast).toHaveBeenCalledWith("abc");
-        expect(console.log).toHaveBeenCalled();
-        const message = console.log.mock.calls[0][0];
-        expect(message).toMatch("abc");
-  
-        restoreConsole();
-      });
-    });
-    describe("cellToAxiosParamsDelete", () => {
-      test("It returns the correct params", () => {
-        // arrange
-        const cell = { row: { values: { "classSections[0].enrollCode": "03452" } } };
-        const psId = 3;
-        // act
-        const result = cellToAxiosParamsDelete({cell: cell, psId: psId});
-  
-        // assert
-        expect(result).toEqual({
-          url: "/api/courses/user/psid",
-          method: "DELETE",
-          params: { enrollCd: "03452",
-          psId: 3 },
-        });
-      });
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/PersonalSectionsUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("CoursesUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
     });
   });
-  
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = {
+        row: { values: { "classSections[0].enrollCode": "03452" } },
+      };
+      const psId = 3;
+      // act
+      const result = cellToAxiosParamsDelete({ cell: cell, psId: psId });
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/courses/user/psid",
+        method: "DELETE",
+        params: { enrollCd: "03452", psId: 3 },
+      });
+    });
+  });
+});

--- a/frontend/src/tests/utils/PersonalSectionsUtils.test.js
+++ b/frontend/src/tests/utils/PersonalSectionsUtils.test.js
@@ -1,0 +1,53 @@
+import {
+    onDeleteSuccess,
+    cellToAxiosParamsDelete,
+  } from "main/utils/PersonalSectionsUtils";
+  import mockConsole from "jest-mock-console";
+  
+  const mockToast = jest.fn();
+  jest.mock("react-toastify", () => {
+    const originalModule = jest.requireActual("react-toastify");
+    return {
+      __esModule: true,
+      ...originalModule,
+      toast: (x) => mockToast(x),
+    };
+  });
+  
+  describe("CoursesUtils", () => {
+    describe("onDeleteSuccess", () => {
+      test("It puts the message on console.log and in a toast", () => {
+        // arrange
+        const restoreConsole = mockConsole();
+  
+        // act
+        onDeleteSuccess("abc");
+  
+        // assert
+        expect(mockToast).toHaveBeenCalledWith("abc");
+        expect(console.log).toHaveBeenCalled();
+        const message = console.log.mock.calls[0][0];
+        expect(message).toMatch("abc");
+  
+        restoreConsole();
+      });
+    });
+    describe("cellToAxiosParamsDelete", () => {
+      test("It returns the correct params", () => {
+        // arrange
+        const cell = { row: { values: { "classSections[0].enrollCode": "03452" } } };
+        const psId = 3;
+        // act
+        const result = cellToAxiosParamsDelete({cell: cell, psId: psId});
+  
+        // assert
+        expect(result).toEqual({
+          url: "/api/courses/user",
+          method: "DELETE",
+          params: { enrollCd: "03452",
+          psId: 3 },
+        });
+      });
+    });
+  });
+  


### PR DESCRIPTION
Created delete button for Personal Sections on the Personal Schedule Details page so that users can delete courses from their schedule here instead of the courses page (which is to be removed).

<img width="1427" alt="image" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/46656629/e3f085dd-6b04-4d0e-9bea-a0c2b1f08214">

dokku deployment: https://proj-jchandev-dev.dokku-02.cs.ucsb.edu
story book link of updated table: https://ucsb-cs156-s24.github.io/proj-courses-s24-4pm-2/prs/52/storybook/?path=/docs/components-personalsections-personalsectionstable--empty

Closes #6 
