### PR TITLE
Kai - add button not showing up for certain courses

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -32,23 +32,30 @@ export function isLectureWithNoSections(enrollCode, sections) {
     // Extract the courseId and section number from the found section
     const courseId = section.courseInfo.courseId;
     const sectionNumber = section.section.section;
+    const courseSections = sections.filter(
+      (section) => section.courseInfo.courseId === courseId,
+    );
+    const timeLocations = section.section.timeLocations;
 
     // Check if the section number is '0100', indicating a lecture
     if (sectionNumber === "0100") {
       // Filter all sections with the same courseId
       // Stryker disable all
-      const courseSections = sections.filter(
-        (section) => section.courseInfo.courseId === courseId,
-      );
       // Stryker restore all
       // Check if there is only one section for the course
       return courseSections.length === 1;
+    } else if (sectionNumber.slice(-2) === "00") {
+      // Check if the section has a location to make sure its a course
+      return (
+        courseSections.length === 1 &&
+        typeof timeLocations !== "undefined" &&
+        timeLocations.length === 1
+      );
     }
   }
 
   return false;
 }
-
 export function isLectureWithSections(enrollCode, sections) {
   // Find the section with the given enrollCode
   const section = sections.find(
@@ -115,7 +122,6 @@ export const onSuccess = (response) => {
 export default function SectionsTable({ sections }) {
   // Stryker restore all
   // Stryker disable BooleanLiteral
-
   const { data: currentUser } = useCurrentUser();
 
   const mutation = useBackendMutation(
@@ -269,10 +275,7 @@ export default function SectionsTable({ sections }) {
               />
             </div>
           );
-        } else if (
-          !isLectureWithSections(value, sections) &&
-          currentUser.loggedIn
-        ) {
+        } else if (!isLectureWithSections(value, sections)) {
           return null;
         } else {
           return (

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -83,8 +83,157 @@ describe("isLectureWithNoSections", () => {
     const enrollCode = "12345";
     const sections = [
       {
-        courseInfo: { courseId: "COURSE1" },
+        courseInfo: { courseId: "COURSE1 -1" },
         section: { enrollCode: "67890", section: "0100" },
+      },
+      {
+        courseInfo: { courseId: "COURSE1 -2" },
+        section: { enrollCode: "67891", section: "0200" },
+      },
+    ];
+
+    const result = isLectureWithNoSections(enrollCode, sections);
+
+    expect(result).toBe(false);
+  });
+  it("should return true when the section number ends in 00 and is not 0100 and has a location", () => {
+    const enrollCode = "12345";
+    const sections = [
+      {
+        courseInfo: { courseId: "COURSE1 -1" },
+        section: {
+          enrollCode: "12345",
+          section: "22200",
+          timeLocations: [
+            {
+              room: "3505",
+              building: "PHELP",
+              roomCapacity: "60",
+              days: " T R   ",
+              beginTime: "08:00",
+              endTime: "09:15",
+            },
+          ],
+        },
+      },
+      {
+        courseInfo: { courseId: "COURSE1 -2" },
+        section: {
+          enrollCode: "12345",
+          section: "22201",
+          timeLocations: [
+            {
+              room: "3505",
+              building: "PHELP",
+              roomCapacity: "60",
+              days: " T R   ",
+              beginTime: "08:00",
+              endTime: "09:15",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = isLectureWithNoSections(enrollCode, sections);
+
+    expect(result).toBe(true);
+  });
+  it("should return false when the section number ends in 00 and is not 0100 and does not have a location", () => {
+    const enrollCode = "12345";
+    const sections = [
+      {
+        courseInfo: { courseId: "COURSE1" },
+        section: {
+          enrollCode: "12345",
+          section: "0200",
+        },
+      },
+    ];
+
+    const result = isLectureWithNoSections(enrollCode, sections);
+
+    expect(result).toBe(false);
+  });
+  it("should return false when the section number does not end in 00", () => {
+    const enrollCode = "12345";
+    const sections = [
+      {
+        courseInfo: { courseId: "COURSE1" },
+        section: {
+          enrollCode: "12345",
+          section: "0201",
+          timeLocations: [
+            {
+              room: "3505",
+              building: "PHELP",
+              roomCapacity: "60",
+              days: " T R   ",
+              beginTime: "08:00",
+              endTime: "09:15",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = isLectureWithNoSections(enrollCode, sections);
+
+    expect(result).toBe(false);
+  });
+  it("should return false when the section number ends in 00 and is not 0100 and has a section", () => {
+    const enrollCode = "12345";
+    const sections = [
+      {
+        courseInfo: { courseId: "COURSE1" },
+        section: {
+          enrollCode: "12345",
+          section: "0200",
+          timeLocations: [
+            {
+              room: "3505",
+              building: "PHELP",
+              roomCapacity: "60",
+              days: " T R   ",
+              beginTime: "08:00",
+              endTime: "09:15",
+            },
+          ],
+        },
+      },
+      {
+        courseInfo: { courseId: "COURSE1" },
+        section: {
+          enrollCode: "12346",
+          section: "0201",
+          timeLocations: [
+            {
+              room: "3505",
+              building: "PHELP",
+              roomCapacity: "60",
+              days: " T R   ",
+              beginTime: "08:00",
+              endTime: "09:15",
+            },
+          ],
+        },
+      },
+    ];
+
+    const result = isLectureWithNoSections(enrollCode, sections);
+
+    expect(result).toBe(false);
+  });
+  it("should return false when the section number ends in 00 and is not 0100 and has time locations not equal to one", () => {
+    const enrollCode = "12345";
+    const sections = [
+      {
+        courseInfo: { courseId: "COURSE1" },
+        section: {
+          enrollCode: "12345",
+          section: "0200",
+          timeLocations: [],
+        },
       },
     ];
 


### PR DESCRIPTION
Courses that have no sections and have section number not equal to "0100" will not include an add button. After looking at the code it seems like the reason is because these courses are interpreted as sections for the same course with the section number "0100"

Before
<img width="1470" alt="Screenshot 2024-05-29 at 6 39 40 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/102753513/c091abec-83aa-485a-b477-7cb4b6cea255">

After
<img width="1484" alt="Screenshot 2024-05-29 at 6 39 49 PM" src="https://github.com/ucsb-cs156-s24/proj-courses-s24-4pm-2/assets/102753513/95d2bba9-3780-4084-a4d9-b7570003076e">

dokku:  https://proj-courses-kai-maeda-dev.dokku-02.cs.ucsb.edu/

Closes #41 
